### PR TITLE
Use single quotes for string literal

### DIFF
--- a/src/Codeception/Lib/Driver/MySql.php
+++ b/src/Codeception/Lib/Driver/MySql.php
@@ -35,7 +35,7 @@ class MySql extends Db
         if (!isset($this->primaryKeys[$tableName])) {
             $primaryKey = [];
             $stmt = $this->getDbh()->query(
-                'SHOW KEYS FROM ' . $this->getQuotedName($tableName) . ' WHERE Key_name = "PRIMARY"'
+                'SHOW KEYS FROM ' . $this->getQuotedName($tableName) . " WHERE Key_name = 'PRIMARY'"
             );
             $columns = $stmt->fetchAll(\PDO::FETCH_ASSOC);
 


### PR DESCRIPTION
This pull request updates the Mysql driver to use single quotes instead of double quotes when querying for a table's primary key

See [Codeception Issue 5778](https://github.com/Codeception/Codeception/issues/5778)