### PR TITLE
MySQL: readSql comment bug

### DIFF
--- a/tests/data/dumps/mysql.sql
+++ b/tests/data/dumps/mysql.sql
@@ -13,6 +13,7 @@ insert  into `groups`(`id`,`name`,`enabled`,`created_at`) values (1,'coders',1,'
 
 insert  into `groups`(`id`,`name`,`enabled`,`created_at`) values (2,'jazzman',0,'2012-02-01 21:18:40');
 
+insert  into `groups`(`id`,`name`,`enabled`,`created_at`) values (2,'A /* Z a \\|`~!\"£$%&/()=\'<>[]{}@#,.;:-_§*+ z',0,'2012-02-01 21:18:40');
 
 CREATE TABLE `users` (
   `id` int(11) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
Replaces https://github.com/Codeception/Codeception/pull/4841

Source of the bug:
https://github.com/Codeception/module-db/blob/13a2b86206d09c50ab2e5375b261df35b650e58f/src/Codeception/Module/Db.php#L498-L501
It shouldn't strip comment-like string that are real data.