### PR TITLE
Add support for IS NOT NULL

### DIFF
--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -215,7 +215,12 @@ class Db
         $params = [];
         foreach ($criteria as $k => $v) {
             if ($v === null) {
-                $params[] = $this->getQuotedName($k) . " IS NULL ";
+                if (stripos($k, ' !=') > 0) {
+                    $params[] = $this->getQuotedName(str_ireplace(" !=", '', $k)) . " IS NOT NULL ";
+                } else {
+                    $params[] = $this->getQuotedName($k) . " IS NULL ";
+                }
+
                 unset($criteria[$k]);
                 continue;
             }

--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -215,8 +215,8 @@ class Db
         $params = [];
         foreach ($criteria as $k => $v) {
             if ($v === null) {
-                if (stripos($k, ' !=') > 0) {
-                    $params[] = $this->getQuotedName(str_ireplace(" !=", '', $k)) . " IS NOT NULL ";
+                if (strpos($k, ' !=') > 0) {
+                    $params[] = $this->getQuotedName(str_replace(" !=", '', $k)) . " IS NOT NULL ";
                 } else {
                     $params[] = $this->getQuotedName($k) . " IS NULL ";
                 }

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -224,6 +224,18 @@ use Codeception\Util\ActionSequence;
  * ```sql
  * SELECT COUNT(*) FROM `users` WHERE `name` = 'Davert' AND `email` LIKE 'davert%'
  * ```
+ * Null comparisons are also available, as shown here:
+ *
+ * ```php
+ * <?php
+ * $I->seeInDatabase('users', ['name' => null, 'email !=' => null]);
+ *
+ * ```
+ * Will generate:
+ *
+ * ```sql
+ * SELECT COUNT(*) FROM `users` WHERE `name` IS NULL AND `email` IS NOT NULL
+ * ```
  * ## Public Properties
  * * dbh - contains the PDO connection
  * * driver - contains the Connection Driver

--- a/tests/unit/Codeception/Lib/Driver/DbTest.php
+++ b/tests/unit/Codeception/Lib/Driver/DbTest.php
@@ -23,12 +23,14 @@ class DbTest extends Unit
     public function getWhereCriteria()
     {
         return [
-            'like' => [['email like' => 'mail.ua'], 'WHERE "email" LIKE ? '],
-            '<='   => [['id <=' => '5'],            'WHERE "id" <= ? '],
-            '<'    => [['id <' => '5'],             'WHERE "id" < ? '],
-            '>='   => [['id >=' => '5'],            'WHERE "id" >= ? '],
-            '>'    => [['id >' => '5'],             'WHERE "id" > ? '],
-            '!='   => [['id !=' => '5'],            'WHERE "id" != ? '],
+            'like'        => [['email like' => 'mail.ua'], 'WHERE "email" LIKE ? '],
+            '<='          => [['id <=' => '5'],            'WHERE "id" <= ? '],
+            '<'           => [['id <' => '5'],             'WHERE "id" < ? '],
+            '>='          => [['id >=' => '5'],            'WHERE "id" >= ? '],
+            '>'           => [['id >' => '5'],             'WHERE "id" > ? '],
+            '!='          => [['id !=' => '5'],            'WHERE "id" != ? '],
+            'is null'     => [['id' => null],              'WHERE "id" IS NULL '],
+            'is not null' => [['id !=' => null],           'WHERE "id" IS NOT NULL '],
         ];
     }
 }


### PR DESCRIPTION
Allows for correct `'value' != null` comparisons in SQL.

I've tested this with MSSQL but the syntax for MySQL looks to be the same.