### PR TITLE
Potential improvement: add support for fake PDO [not ready to merge]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea/
 /vendor/
 /composer.lock
+composer.phar

--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -65,7 +65,8 @@ class Db
      */
     public static function create($dsn, $user, $password, $options = null)
     {
-        $provider = self::getProvider($dsn);
+	    list($real_dsn) = self::checkForFakePdo($dsn);
+        $provider = self::getProvider($real_dsn);
 
         switch ($provider) {
             case 'sqlite':


### PR DESCRIPTION
This is quite a speculative PR so please consider it one for discussion rather than immediate merge or refusal either way. I thought it better to open as a PR rather than an issue so that we can discuss the code implications.

There's a new tool released that provides a [fake implementation of PDO](https://github.com/vimeo/php-mysql-engine) allowing for database driven tests to be run against essentially a fake database implemented in PHP. This could significantly reduce test runtimes by avoiding database network connections/sockets and by reducing disk i/o. It is currently limited in some ways - it doesn't support triggers or views, and some parsing is incomplete, but the core is there.

I have worked on implementing this in Codeception and have been able to run an initial database creation from a schema file, and have got to running tests. It fails at `haveInDatabase` for mysql specifically because the parser lacks support for `show indexes` but this can be worked on.

To implement it in the Codeception module I added a keyword `fake:` to the start of the `DSN` which gets stripped off and used to start the fake PDO driver rather than a real one. FakePdo uses static storage under the hood to represent a database, meaning that the same FakePdo created on module initialization would be available for userland access if test code injected FakePdo instead of real PDO into application code.

As far as I can see merging this would have no impacts unless someone chose to add `fake:` to the start of their DSN; at this point they'd need to have installed the `vimeo/php-mysql-engine` package or Codeception would crash on startup. I thought that preferable to making that package a dependency.

Let me know if this is something we might merge, or if there are better ways to implement this as an optional plugin without having to re-implement all the other features of this module.