### PR TITLE
Fix not primary auto_increment case

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -770,7 +770,7 @@ class Db extends CodeceptionModule implements DbInterface
         $primary = [];
         if ($primaryKey) {
             foreach ($primaryKey as $column) {
-                if (isset($row[$column])) {
+                if (isset($row[$column]) || $id) {
                     $primary[$column] = isset($row[$column]) ? $row[$column] : $id;
                 } else {
                     throw new \InvalidArgumentException(

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -771,7 +771,7 @@ class Db extends CodeceptionModule implements DbInterface
         if ($primaryKey) {
             foreach ($primaryKey as $column) {
                 if (isset($row[$column])) {
-                    $primary[$column] = $row[$column] ?? $id;
+                    $primary[$column] = isset($row[$column]) ? $row[$column] : $id;
                 } else {
                     throw new \InvalidArgumentException(
                         'Primary key field ' . $column . ' is not set for table ' . $table

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -769,17 +769,13 @@ class Db extends CodeceptionModule implements DbInterface
         $primaryKey = $this->_getDriver()->getPrimaryKey($table);
         $primary = [];
         if ($primaryKey) {
-            if ($id && count($primaryKey) === 1) {
-                $primary [$primaryKey[0]] = $id;
-            } else {
-                foreach ($primaryKey as $column) {
-                    if (isset($row[$column])) {
-                        $primary[$column] = $row[$column];
-                    } else {
-                        throw new \InvalidArgumentException(
-                            'Primary key field ' . $column . ' is not set for table ' . $table
-                        );
-                    }
+            foreach ($primaryKey as $column) {
+                if (isset($row[$column])) {
+                    $primary[$column] = $row[$column] ?? $id;
+                } else {
+                    throw new \InvalidArgumentException(
+                        'Primary key field ' . $column . ' is not set for table ' . $table
+                    );
                 }
             }
         } else {


### PR DESCRIPTION
The assumption that auto_increment is always the value for primary key is wrong.

As example:
* there is a table user, where primary id is - userId which is a md5 random string.
* Autoincrement is on the userNumber field, which is not primary, but by some reason it is there.

Now we add a user with haveInDatabase, and with specific id:['userId'=>'special']; what will endup in insertedRows? usesrId => 10 but should be userId=>'special'. As insertId for user was 10, and sure, it will not be cleaned up.