### PR TITLE
Code standards updated to PHP 7.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0]
 
     steps:
     - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -1,30 +1,34 @@
 {
-    "name":"codeception/module-db",
-    "description":"DB module for Codeception",
-    "keywords":["codeception", "db-testing", "database-testing"],
-    "homepage":"http://codeception.com/",
-    "type":"library",
-    "license":"MIT",
-    "authors":[
-        {
-            "name": "Michael Bodnarchuk"
-        },
-        {
-            "name": "Gintautas Miselis"
-        }
-    ],
-    "minimum-stability": "RC",
-    "require": {
-        "php": ">=5.6.0 <9.0",
-        "codeception/codeception": "*@dev"
-    },
-    "conflict": {
-        "codeception/codeception": "<4.0"
-    },
-    "autoload":{
-        "classmap": ["src/"]
-    },
-    "config": {
-        "classmap-authoritative": true
-    }
+	"name": "codeception/module-db",
+	"description": "DB module for Codeception",
+	"keywords": [ "codeception", "db-testing", "database-testing" ],
+	"homepage": "http://codeception.com/",
+	"type": "library",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Michael Bodnarchuk"
+		},
+		{
+			"name": "Gintautas Miselis"
+		}
+	],
+	"minimum-stability": "RC",
+	"require": {
+		"php": "^7.1 || ^8.0",
+		"ext-json": "*",
+		"ext-pdo": "*",
+		"codeception/codeception": "*@dev"
+	},
+	"conflict": {
+		"codeception/codeception": "<4.0"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"config": {
+		"classmap-authoritative": true
+	}
 }

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,10 @@ A database module for Codeception.
 [![Total Downloads](https://poser.pugx.org/codeception/module-db/downloads)](https://packagist.org/packages/codeception/module-db)
 [![License](https://poser.pugx.org/codeception/module-db/license)](/LICENSE)
 
+## Requirements
+
+* `PHP 7.1` or higher.
+
 ## Installation
 
 ```

--- a/src/Codeception/Lib/DbPopulator.php
+++ b/src/Codeception/Lib/DbPopulator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Lib;
 
 /**
@@ -10,12 +12,12 @@ class DbPopulator
     /**
      * @var array
      */
-    protected $config;
+    protected $config = [];
 
     /**
      * @var array
      */
-    protected $commands;
+    protected $commands = [];
 
     /**
      * Constructs a DbPopulator object for the given command and Db module.
@@ -27,11 +29,14 @@ class DbPopulator
     public function __construct($config)
     {
         $this->config = $config;
-
         //Convert To Array Format
-        if (isset($this->config['dump']) && !is_array($this->config['dump'])) {
-            $this->config['dump'] = [$this->config['dump']];
+        if (!isset($this->config['dump'])) {
+            return;
         }
+        if (is_array($this->config['dump'])) {
+            return;
+        }
+        $this->config['dump'] = [$this->config['dump']];
     }
 
     /**
@@ -53,15 +58,15 @@ class DbPopulator
      * @param string|null $dumpFile The dump file to build the command with.
      * @return string The resulting command string after evaluating any configuration's key
      */
-    protected function buildCommand($command, $dumpFile = null)
+    protected function buildCommand(string $command, ?string $dumpFile = null): string
     {
-        $dsn = isset($this->config['dsn']) ? $this->config['dsn'] : '';
+        $dsn = $this->config['dsn'] ?? '';
         $dsnVars = [];
-        $dsnWithoutDriver = preg_replace('/^[a-z]+:/i', '', $dsn);
+        $dsnWithoutDriver = preg_replace('#^[a-z]+:#i', '', $dsn);
         foreach (explode(';', $dsnWithoutDriver) as $item) {
             $keyValueTuple = explode('=', $item);
             if (count($keyValueTuple) > 1) {
-                list($k, $v) = array_values($keyValueTuple);
+                [$k, $v] = array_values($keyValueTuple);
                 $dsnVars[$k] = $v;
             }
         }
@@ -86,10 +91,8 @@ class DbPopulator
      * Executes the command built using the Db module configuration.
      *
      * Uses the PHP `exec` to spin off a child process for the built command.
-     *
-     * @return bool
      */
-    public function run()
+    public function run(): bool
     {
         foreach ($this->buildCommands() as $command) {
             $this->runCommand($command);
@@ -98,16 +101,16 @@ class DbPopulator
         return true;
     }
 
-    private function runCommand($command)
+    private function runCommand($command): void
     {
-        codecept_debug("[Db] Executing Populator: `$command`");
+        codecept_debug(sprintf('[Db] Executing Populator: `%s`', $command));
 
         exec($command, $output, $exitCode);
 
         if (0 !== $exitCode) {
             throw new \RuntimeException(
                 "The populator command did not end successfully: \n" .
-                "  Exit code: $exitCode \n" .
+                "  Exit code: {$exitCode} \n" .
                 "  Output:" . implode("\n", $output)
             );
         }
@@ -115,14 +118,13 @@ class DbPopulator
         codecept_debug("[Db] Populator Finished.");
     }
 
-    public function buildCommands()
+    public function buildCommands(): array
     {
-        if ($this->commands !== null) {
+        if ($this->commands !== []) {
             return $this->commands;
         } elseif (!isset($this->config['dump']) || $this->config['dump'] === false) {
             return [$this->buildCommand($this->config['populator'])];
         }
-
         $this->commands = [];
 
         foreach ($this->config['dump'] as $dumpFile) {

--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -6,6 +6,7 @@ namespace Codeception\Lib\Driver;
 
 use Codeception\Exception\ModuleException;
 use Exception;
+use InvalidArgumentException;
 use PDO;
 use PDOException;
 use PDOStatement;
@@ -142,7 +143,10 @@ class Db
     {
     }
 
-    public function load($sql): void
+    /**
+     * @param string[] $sql
+     */
+    public function load(array $sql): void
     {
         $query = '';
         $delimiter = ';';
@@ -173,7 +177,7 @@ class Db
         }
     }
 
-    public function insert($tableName, array &$data): string
+    public function insert(string $tableName, array &$data): string
     {
         $columns = array_map(
             function ($name) {
@@ -190,12 +194,12 @@ class Db
         );
     }
 
-    public function select($column, $table, array &$criteria): string
+    public function select(string $column, string $tableName, array &$criteria): string
     {
         $where = $this->generateWhereClause($criteria);
 
         $query = "SELECT %s FROM %s %s";
-        return sprintf($query, $column, $this->getQuotedName($table), $where);
+        return sprintf($query, $column, $this->getQuotedName($tableName), $where);
     }
 
     private function getSupportedOperators(): array
@@ -253,25 +257,25 @@ class Db
         return 'WHERE ' . implode('AND ', $params);
     }
 
-    public function deleteQueryByCriteria($table, array $criteria): void
+    public function deleteQueryByCriteria(string $tableName, array $criteria): void
     {
         $where = $this->generateWhereClause($criteria);
 
-        $query = 'DELETE FROM ' . $this->getQuotedName($table) . ' ' . $where;
+        $query = 'DELETE FROM ' . $this->getQuotedName($tableName) . ' ' . $where;
         $this->executeQuery($query, array_values($criteria));
     }
 
-    public function lastInsertId($table): string
+    public function lastInsertId(string $tableName): string
     {
         return $this->getDbh()->lastInsertId();
     }
 
-    public function getQuotedName($name): string
+    public function getQuotedName(string $name): string
     {
         return '"' . str_replace('.', '"."', $name) . '"';
     }
 
-    public function sqlLine($sql): bool
+    protected function sqlLine(string $sql): bool
     {
         $sql = trim($sql);
         return (
@@ -281,7 +285,7 @@ class Db
         );
     }
 
-    public function sqlQuery($query): void
+    protected function sqlQuery(string $query): void
     {
         try {
             $this->dbh->exec($query);
@@ -332,10 +336,10 @@ class Db
         return empty($this->primaryKeys);
     }
 
-    public function update($table, array $data, array $criteria): string
+    public function update(string $tableName, array $data, array $criteria): string
     {
         if (empty($data)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Query update can't be prepared without data."
             );
         }
@@ -347,7 +351,7 @@ class Db
 
         $where = $this->generateWhereClause($criteria);
 
-        return sprintf('UPDATE %s SET %s %s', $this->getQuotedName($table), implode(', ', $set), $where);
+        return sprintf('UPDATE %s SET %s %s', $this->getQuotedName($tableName), implode(', ', $set), $where);
     }
 
     public function getOptions(): array

--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -1,13 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Lib\Driver;
 
 use Codeception\Exception\ModuleException;
+use Exception;
+use PDO;
+use PDOException;
+use PDOStatement;
 
 class Db
 {
     /**
-     * @var \PDO
+     * @var PDO
      */
     protected $dbh;
 
@@ -24,7 +30,7 @@ class Db
      *
      * @see http://php.net/manual/de/pdo.construct.php
      */
-    protected $options;
+    protected $options = [];
 
     /**
      * associative array with table name => primary-key
@@ -33,10 +39,10 @@ class Db
      */
     protected $primaryKeys = [];
 
-    public static function connect($dsn, $user, $password, $options = null)
+    public static function connect($dsn, $user, $password, $options = null): PDO
     {
-        $dbh = new \PDO($dsn, $user, $password, $options);
-        $dbh->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $dbh = new PDO($dsn, $user, $password, $options);
+        $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
         return $dbh;
     }
@@ -54,7 +60,7 @@ class Db
      *
      * @return Db|SqlSrv|MySql|Oci|PostgreSql|Sqlite
      */
-    public static function create($dsn, $user, $password, $options = null)
+    public static function create($dsn, $user, $password, $options = null): Db
     {
         $provider = self::getProvider($dsn);
 
@@ -76,7 +82,7 @@ class Db
         }
     }
 
-    public static function getProvider($dsn)
+    public static function getProvider($dsn): string
     {
         return substr($dsn, 0, strpos($dsn, ':'));
     }
@@ -92,8 +98,8 @@ class Db
      */
     public function __construct($dsn, $user, $password, $options = null)
     {
-        $this->dbh = new \PDO($dsn, $user, $password, $options);
-        $this->dbh->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $this->dbh = new PDO($dsn, $user, $password, $options);
+        $this->dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
         $this->dsn = $dsn;
         $this->user = $user;
@@ -109,7 +115,7 @@ class Db
         $this->dbh = null;
     }
 
-    public function getDbh()
+    public function getDbh(): PDO
     {
         return $this->dbh;
     }
@@ -117,7 +123,7 @@ class Db
     public function getDb()
     {
         $matches = [];
-        $matched = preg_match('~dbname=(\w+)~s', $this->dsn, $matches);
+        $matched = preg_match('#dbname=(\w+)#s', $this->dsn, $matches);
         if (!$matched) {
             return false;
         }
@@ -131,32 +137,30 @@ class Db
 
     /**
      * Set the lock waiting interval for the database session
-     * @param int $seconds
-     * @return void
      */
-    public function setWaitLock($seconds)
+    public function setWaitLock(int $seconds): void
     {
     }
 
-    public function load($sql)
+    public function load($sql): void
     {
         $query = '';
         $delimiter = ';';
         $delimiterLength = 1;
 
-        foreach ($sql as $sqlLine) {
-            if (preg_match('/DELIMITER ([\;\$\|\\\\]+)/i', $sqlLine, $match)) {
+        foreach ($sql as $singleSql) {
+            if (preg_match('#DELIMITER ([\;\$\|\\\]+)#i', $singleSql, $match)) {
                 $delimiter = $match[1];
                 $delimiterLength = strlen($delimiter);
                 continue;
             }
 
-            $parsed = $this->sqlLine($sqlLine);
+            $parsed = $this->sqlLine($singleSql);
             if ($parsed) {
                 continue;
             }
 
-            $query .= "\n" . rtrim($sqlLine);
+            $query .= "\n" . rtrim($singleSql);
 
             if (substr($query, -1 * $delimiterLength, $delimiterLength) == $delimiter) {
                 $this->sqlQuery(substr($query, 0, -1 * $delimiterLength));
@@ -169,10 +173,12 @@ class Db
         }
     }
 
-    public function insert($tableName, array &$data)
+    public function insert($tableName, array &$data): string
     {
         $columns = array_map(
-            [$this, 'getQuotedName'],
+            function ($name) {
+                return $this->getQuotedName($name);
+            },
             array_keys($data)
         );
 
@@ -184,7 +190,7 @@ class Db
         );
     }
 
-    public function select($column, $table, array &$criteria)
+    public function select($column, $table, array &$criteria): string
     {
         $where = $this->generateWhereClause($criteria);
 
@@ -192,7 +198,7 @@ class Db
         return sprintf($query, $column, $this->getQuotedName($table), $where);
     }
 
-    private function getSupportedOperators()
+    private function getSupportedOperators(): array
     {
         return [
             'like',
@@ -204,7 +210,7 @@ class Db
         ];
     }
 
-    protected function generateWhereClause(array &$criteria)
+    protected function generateWhereClause(array &$criteria): string
     {
         if (empty($criteria)) {
             return '';
@@ -247,7 +253,7 @@ class Db
         return 'WHERE ' . implode('AND ', $params);
     }
 
-    public function deleteQueryByCriteria($table, array $criteria)
+    public function deleteQueryByCriteria($table, array $criteria): void
     {
         $where = $this->generateWhereClause($criteria);
 
@@ -255,83 +261,78 @@ class Db
         $this->executeQuery($query, array_values($criteria));
     }
 
-    public function lastInsertId($table)
+    public function lastInsertId($table): string
     {
         return $this->getDbh()->lastInsertId();
     }
 
-    public function getQuotedName($name)
+    public function getQuotedName($name): string
     {
         return '"' . str_replace('.', '"."', $name) . '"';
     }
 
-    protected function sqlLine($sql)
+    public function sqlLine($sql): bool
     {
         $sql = trim($sql);
         return (
             $sql === ''
             || $sql === ';'
-            || preg_match('~^((--.*?)|(#))~s', $sql)
+            || preg_match('#^((--.*?)|(\#))#s', $sql)
         );
     }
 
-    protected function sqlQuery($query)
+    public function sqlQuery($query): void
     {
         try {
             $this->dbh->exec($query);
-        } catch (\PDOException $e) {
+        } catch (PDOException $pdoException) {
             throw new ModuleException(
-                'Codeception\Module\Db',
-                $e->getMessage() . "\nSQL query being executed: " . $query
+                \Codeception\Module\Db::class,
+                $pdoException->getMessage() . "\nSQL query being executed: " . $query
             );
         }
     }
 
-    public function executeQuery($query, array $params)
+    public function executeQuery($query, array $params): PDOStatement
     {
-        $sth = $this->dbh->prepare($query);
-        if (!$sth) {
-            throw new \Exception("Query '$query' can't be prepared.");
+        $pdoStatement = $this->dbh->prepare($query);
+        if (!$pdoStatement) {
+            throw new Exception("Query '{$query}' can't be prepared.");
         }
 
         $i = 0;
-        foreach ($params as $value) {
-            $i++;
-            if (is_bool($value)) {
-                $type = \PDO::PARAM_BOOL;
-            } elseif (is_int($value)) {
-                $type = \PDO::PARAM_INT;
+        foreach ($params as $param) {
+            ++$i;
+            if (is_bool($param)) {
+                $type = PDO::PARAM_BOOL;
+            } elseif (is_int($param)) {
+                $type = PDO::PARAM_INT;
             } else {
-                $type = \PDO::PARAM_STR;
+                $type = PDO::PARAM_STR;
             }
-            $sth->bindValue($i, $value, $type);
+            $pdoStatement->bindValue($i, $param, $type);
         }
 
-        $sth->execute();
-        return $sth;
+        $pdoStatement->execute();
+        return $pdoStatement;
     }
 
     /**
-     * @param string $tableName
-     *
-     * @return array[string]
+     * @return string[]
      */
-    public function getPrimaryKey($tableName)
+    public function getPrimaryKey(string $tableName): array
     {
         return [];
     }
 
-    /**
-     * @return bool
-     */
-    protected function flushPrimaryColumnCache()
+    protected function flushPrimaryColumnCache(): bool
     {
         $this->primaryKeys = [];
 
         return empty($this->primaryKeys);
     }
 
-    public function update($table, array $data, array $criteria)
+    public function update($table, array $data, array $criteria): string
     {
         if (empty($data)) {
             throw new \InvalidArgumentException(
@@ -340,7 +341,7 @@ class Db
         }
 
         $set = [];
-        foreach ($data as $column => $value) {
+        foreach (array_keys($data) as $column) {
             $set[] = $this->getQuotedName($column) . " = ?";
         }
 
@@ -349,7 +350,7 @@ class Db
         return sprintf('UPDATE %s SET %s %s', $this->getQuotedName($table), implode(', ', $set), $where);
     }
 
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }

--- a/src/Codeception/Lib/Driver/MySql.php
+++ b/src/Codeception/Lib/Driver/MySql.php
@@ -1,9 +1,14 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Driver;
+
+use PDO;
 
 class MySql extends Db
 {
-    public function cleanup()
+    public function cleanup(): void
     {
         $this->dbh->exec('SET FOREIGN_KEY_CHECKS=0;');
         $res = $this->dbh->query("SHOW FULL TABLES WHERE TABLE_TYPE LIKE '%TABLE';")->fetchAll();
@@ -13,31 +18,29 @@ class MySql extends Db
         $this->dbh->exec('SET FOREIGN_KEY_CHECKS=1;');
     }
 
-    protected function sqlQuery($query)
+    public function sqlQuery($query): void
     {
         $this->dbh->exec('SET FOREIGN_KEY_CHECKS=0;');
         parent::sqlQuery($query);
         $this->dbh->exec('SET FOREIGN_KEY_CHECKS=1;');
     }
 
-    public function getQuotedName($name)
+    public function getQuotedName($name): string
     {
         return '`' . str_replace('.', '`.`', $name) . '`';
     }
 
     /**
-     * @param string $tableName
-     *
-     * @return array[string]
+     * @return string[]
      */
-    public function getPrimaryKey($tableName)
+    public function getPrimaryKey(string $tableName): array
     {
         if (!isset($this->primaryKeys[$tableName])) {
             $primaryKey = [];
             $stmt = $this->getDbh()->query(
                 'SHOW KEYS FROM ' . $this->getQuotedName($tableName) . " WHERE Key_name = 'PRIMARY'"
             );
-            $columns = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+            $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
             foreach ($columns as $column) {
                 $primaryKey []= $column['Column_name'];

--- a/src/Codeception/Lib/Driver/MySql.php
+++ b/src/Codeception/Lib/Driver/MySql.php
@@ -18,14 +18,14 @@ class MySql extends Db
         $this->dbh->exec('SET FOREIGN_KEY_CHECKS=1;');
     }
 
-    public function sqlQuery($query): void
+    public function sqlQuery(string $query): void
     {
         $this->dbh->exec('SET FOREIGN_KEY_CHECKS=0;');
         parent::sqlQuery($query);
         $this->dbh->exec('SET FOREIGN_KEY_CHECKS=1;');
     }
 
-    public function getQuotedName($name): string
+    public function getQuotedName(string $name): string
     {
         return '`' . str_replace('.', '`.`', $name) . '`';
     }

--- a/src/Codeception/Lib/Driver/Oci.php
+++ b/src/Codeception/Lib/Driver/Oci.php
@@ -53,9 +53,9 @@ class Oci extends Db
      * IF you do not want to load triggers you can use the `;` characters
      * but in this case you need to change the $delimiter from `//` to `;`
      *
-     * @param $sql
+     * @param string[] $sql
      */
-    public function load($sql): void
+    public function load(array $sql): void
     {
         $query = '';
         $delimiter = '//';

--- a/src/Codeception/Lib/Driver/Oci.php
+++ b/src/Codeception/Lib/Driver/Oci.php
@@ -1,14 +1,17 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Driver;
 
 class Oci extends Db
 {
-    public function setWaitLock($seconds)
+    public function setWaitLock(int $seconds): void
     {
-        $this->dbh->exec('ALTER SESSION SET ddl_lock_timeout = ' . (int) $seconds);
+        $this->dbh->exec('ALTER SESSION SET ddl_lock_timeout = ' . $seconds);
     }
 
-    public function cleanup()
+    public function cleanup(): void
     {
         $this->dbh->exec(
             "BEGIN
@@ -52,25 +55,25 @@ class Oci extends Db
      *
      * @param $sql
      */
-    public function load($sql)
+    public function load($sql): void
     {
         $query = '';
         $delimiter = '//';
         $delimiterLength = 2;
 
-        foreach ($sql as $sqlLine) {
-            if (preg_match('/DELIMITER ([\;\$\|\\\\]+)/i', $sqlLine, $match)) {
+        foreach ($sql as $singleSql) {
+            if (preg_match('#DELIMITER ([\;\$\|\\\]+)#i', $singleSql, $match)) {
                 $delimiter = $match[1];
                 $delimiterLength = strlen($delimiter);
                 continue;
             }
 
-            $parsed = $this->sqlLine($sqlLine);
+            $parsed = $this->sqlLine($singleSql);
             if ($parsed) {
                 continue;
             }
 
-            $query .= "\n" . rtrim($sqlLine);
+            $query .= "\n" . rtrim($singleSql);
 
             if (substr($query, -1 * $delimiterLength, $delimiterLength) == $delimiter) {
                 $this->sqlQuery(substr($query, 0, -1 * $delimiterLength));
@@ -84,11 +87,9 @@ class Oci extends Db
     }
 
     /**
-     * @param string $tableName
-     *
-     * @return array[string]
+     * @return string[]
      */
-    public function getPrimaryKey($tableName)
+    public function getPrimaryKey(string $tableName): array
     {
         if (!isset($this->primaryKeys[$tableName])) {
             $primaryKey = [];

--- a/src/Codeception/Lib/Driver/PostgreSql.php
+++ b/src/Codeception/Lib/Driver/PostgreSql.php
@@ -25,9 +25,9 @@ class PostgreSql extends Db
     /**
      * Loads a SQL file.
      *
-     * @param string $sql sql file
+     * @param string[] $sql sql file
      */
-    public function load($sql): void
+    public function load(array $sql): void
     {
         $query = '';
         $delimiter = ';';
@@ -77,7 +77,7 @@ class PostgreSql extends Db
         $this->dbh->exec('CREATE SCHEMA public;');
     }
 
-    public function sqlLine($sql): bool
+    public function sqlLine(string $sql): bool
     {
         if (!$this->putline) {
             return parent::sqlLine($sql);
@@ -95,7 +95,7 @@ class PostgreSql extends Db
         return true;
     }
 
-    public function sqlQuery($query): void
+    public function sqlQuery(string $query): void
     {
         if (strpos(trim($query), 'COPY ') === 0) {
             if (!extension_loaded('pgsql')) {
@@ -123,14 +123,14 @@ class PostgreSql extends Db
     /**
      * Get the last inserted ID of table.
      */
-    public function lastInsertId($table): string
+    public function lastInsertId(string $tableName): string
     {
         /*
          * We make an assumption that the sequence name for this table
          * is based on how postgres names sequences for SERIAL columns
          */
 
-        $sequenceName = $this->getQuotedName($table . '_id_seq');
+        $sequenceName = $this->getQuotedName($tableName . '_id_seq');
         $lastSequence = null;
 
         try {
@@ -142,9 +142,9 @@ class PostgreSql extends Db
         // here we check if for instance, it's something like table_primary_key_seq instead of table_id_seq
         // this could occur when you use some kind of import tool like pgloader
         if (!$lastSequence) {
-            $primaryKeys = $this->getPrimaryKey($table);
+            $primaryKeys = $this->getPrimaryKey($tableName);
             $pkName = array_shift($primaryKeys);
-            $lastSequence = $this->getDbh()->lastInsertId($this->getQuotedName($table . '_' . $pkName . '_seq'));
+            $lastSequence = $this->getDbh()->lastInsertId($this->getQuotedName($tableName . '_' . $pkName . '_seq'));
         }
 
         return $lastSequence;

--- a/src/Codeception/Lib/Driver/PostgreSql.php
+++ b/src/Codeception/Lib/Driver/PostgreSql.php
@@ -1,54 +1,64 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Lib\Driver;
 
 use Codeception\Exception\ModuleException;
+use PDO;
+use PDOException;
 
 class PostgreSql extends Db
 {
+    /**
+     * @var bool
+     */
     protected $putline = false;
 
-    protected $connection = null;
+    /**
+     * @var null|resource|bool
+     */
+    protected $connection;
 
-    protected $searchPath = null;
+    protected $searchPath;
 
     /**
      * Loads a SQL file.
      *
      * @param string $sql sql file
      */
-    public function load($sql)
+    public function load($sql): void
     {
         $query = '';
         $delimiter = ';';
         $delimiterLength = 1;
 
         $dollarsOpen = false;
-        foreach ($sql as $sqlLine) {
-            if (preg_match('/DELIMITER ([\;\$\|\\\\]+)/i', $sqlLine, $match)) {
+        foreach ($sql as $singleSql) {
+            if (preg_match('#DELIMITER ([\;\$\|\\\]+)#i', $singleSql, $match)) {
                 $delimiter = $match[1];
                 $delimiterLength = strlen($delimiter);
                 continue;
             }
 
-            $parsed = trim($query) == '' && $this->sqlLine($sqlLine);
+            $parsed = trim($query) == '' && $this->sqlLine($singleSql);
             if ($parsed) {
                 continue;
             }
 
             // Ignore $$ inside SQL standard string syntax such as in INSERT statements.
-            if (!preg_match('/\'.*\$\$.*\'/', $sqlLine)) {
-                $pos = strpos($sqlLine, '$$');
+            if (!preg_match('#\'.*\$\$.*\'#', $singleSql)) {
+                $pos = strpos($singleSql, '$$');
                 if (($pos !== false) && ($pos >= 0)) {
                     $dollarsOpen = !$dollarsOpen;
                 }
             }
 
-            if (preg_match('/SET search_path = .*/i', $sqlLine, $match)) {
+            if (preg_match('#SET search_path = .*#i', $singleSql, $match)) {
                 $this->searchPath = $match[0];
             }
 
-            $query .= "\n" . rtrim($sqlLine);
+            $query .= "\n" . rtrim($singleSql);
 
             if (!$dollarsOpen && substr($query, -1 * $delimiterLength, $delimiterLength) == $delimiter) {
                 $this->sqlQuery(substr($query, 0, -1 * $delimiterLength));
@@ -61,13 +71,13 @@ class PostgreSql extends Db
         }
     }
 
-    public function cleanup()
+    public function cleanup(): void
     {
         $this->dbh->exec('DROP SCHEMA IF EXISTS public CASCADE;');
         $this->dbh->exec('CREATE SCHEMA public;');
     }
 
-    public function sqlLine($sql)
+    public function sqlLine($sql): bool
     {
         if (!$this->putline) {
             return parent::sqlLine($sql);
@@ -85,19 +95,19 @@ class PostgreSql extends Db
         return true;
     }
 
-    public function sqlQuery($query)
+    public function sqlQuery($query): void
     {
         if (strpos(trim($query), 'COPY ') === 0) {
             if (!extension_loaded('pgsql')) {
                 throw new ModuleException(
-                    '\Codeception\Module\Db',
+                    \Codeception\Module\Db::class,
                     "To run 'COPY' commands 'pgsql' extension should be installed"
                 );
             }
-            $constring = str_replace(';', ' ', substr($this->dsn, 6));
-            $constring .= ' user=' . $this->user;
-            $constring .= ' password=' . $this->password;
-            $this->connection = pg_connect($constring);
+            $strConn = str_replace(';', ' ', substr($this->dsn, 6));
+            $strConn .= ' user=' . $this->user;
+            $strConn .= ' password=' . $this->password;
+            $this->connection = pg_connect($strConn);
 
             if ($this->searchPath !== null) {
                 pg_query($this->connection, $this->searchPath);
@@ -113,7 +123,7 @@ class PostgreSql extends Db
     /**
      * Get the last inserted ID of table.
      */
-    public function lastInsertId($table)
+    public function lastInsertId($table): string
     {
         /*
          * We make an assumption that the sequence name for this table
@@ -125,7 +135,7 @@ class PostgreSql extends Db
 
         try {
             $lastSequence = $this->getDbh()->lastInsertId($sequenceName);
-        } catch (\PDOException $e) {
+        } catch (PDOException $pdoException) {
             // in this case, the sequence name might be combined with the primary key name
         }
 
@@ -144,11 +154,9 @@ class PostgreSql extends Db
      * Returns the primary key(s) of the table, based on:
      * https://wiki.postgresql.org/wiki/Retrieve_primary_key_columns.
      *
-     * @param string $tableName
-     *
-     * @return array[string]
+     * @return string[]
      */
-    public function getPrimaryKey($tableName)
+    public function getPrimaryKey(string $tableName): array
     {
         if (!isset($this->primaryKeys[$tableName])) {
             $primaryKey = [];
@@ -156,10 +164,10 @@ class PostgreSql extends Db
                 FROM   pg_index i
                 JOIN   pg_attribute a ON a.attrelid = i.indrelid
                                      AND a.attnum = ANY(i.indkey)
-                WHERE  i.indrelid = '$tableName'::regclass
+                WHERE  i.indrelid = '{$tableName}'::regclass
                 AND    i.indisprimary";
             $stmt = $this->executeQuery($query, []);
-            $columns = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+            $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
             foreach ($columns as $column) {
                 $primaryKey []= $column['attname'];
             }

--- a/src/Codeception/Lib/Driver/SqlSrv.php
+++ b/src/Codeception/Lib/Driver/SqlSrv.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Codeception\Lib\Driver;
 
+use PDO;
+
 class SqlSrv extends Db
 {
     public function getDb()
@@ -51,7 +53,7 @@ class SqlSrv extends Db
         );
     }
 
-    public function getQuotedName($name): string
+    public function getQuotedName(string $name): string
     {
         return '[' . str_replace('.', '].[', $name) . ']';
     }
@@ -72,7 +74,7 @@ class SqlSrv extends Db
                     AND Col.Table_Name = Tab.Table_Name
                     AND Constraint_Type = 'PRIMARY KEY' AND Col.Table_Name = ?";
             $stmt = $this->executeQuery($query, [$tableName]);
-            $columns = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+            $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
             foreach ($columns as $column) {
                 $primaryKey []= $column['Column_Name'];

--- a/src/Codeception/Lib/Driver/SqlSrv.php
+++ b/src/Codeception/Lib/Driver/SqlSrv.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Driver;
 
 class SqlSrv extends Db
@@ -6,7 +9,7 @@ class SqlSrv extends Db
     public function getDb()
     {
         $matches = [];
-        $matched = preg_match('~Database=(.*);?~s', $this->dsn, $matches);
+        $matched = preg_match('#Database=(.*);?#s', $this->dsn, $matches);
 
         if (!$matched) {
             return false;
@@ -15,7 +18,7 @@ class SqlSrv extends Db
         return $matches[1];
     }
 
-    public function cleanup()
+    public function cleanup(): void
     {
         $this->dbh->exec(
             "
@@ -48,17 +51,15 @@ class SqlSrv extends Db
         );
     }
 
-    public function getQuotedName($name)
+    public function getQuotedName($name): string
     {
         return '[' . str_replace('.', '].[', $name) . ']';
     }
 
     /**
-     * @param string $tableName
-     *
-     * @return array[string]
+     * @return string[]
      */
-    public function getPrimaryKey($tableName)
+    public function getPrimaryKey(string $tableName): array
     {
         if (!isset($this->primaryKeys[$tableName])) {
             $primaryKey = [];

--- a/src/Codeception/Lib/Driver/Sqlite.php
+++ b/src/Codeception/Lib/Driver/Sqlite.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Lib\Driver;
 
 use Codeception\Configuration;
@@ -6,9 +9,15 @@ use Codeception\Exception\ModuleException;
 
 class Sqlite extends Db
 {
+    /**
+     * @var bool
+     */
     protected $hasSnapshot = false;
+    /**
+     * @var string
+     */
     protected $filename = '';
-    protected $con = null;
+    protected $con;
 
     public function __construct($dsn, $user, $password, $options = null)
     {
@@ -22,7 +31,7 @@ class Sqlite extends Db
         parent::__construct($this->dsn, $user, $password, $options);
     }
 
-    public function cleanup()
+    public function cleanup(): void
     {
         $this->dbh = null;
         gc_collect_cycles();
@@ -30,7 +39,7 @@ class Sqlite extends Db
         $this->dbh = self::connect($this->dsn, $this->user, $this->password);
     }
 
-    public function load($sql)
+    public function load($sql): void
     {
         if ($this->hasSnapshot) {
             $this->dbh = null;
@@ -47,11 +56,9 @@ class Sqlite extends Db
     }
 
     /**
-     * @param string $tableName
-     *
-     * @return array[string]
+     * @return string[]
      */
-    public function getPrimaryKey($tableName)
+    public function getPrimaryKey(string $tableName): array
     {
         if (!isset($this->primaryKeys[$tableName])) {
             if ($this->hasRowId($tableName)) {
@@ -75,11 +82,7 @@ class Sqlite extends Db
         return $this->primaryKeys[$tableName];
     }
 
-    /**
-     * @param $tableName
-     * @return bool
-     */
-    private function hasRowId($tableName)
+    private function hasRowId($tableName): bool
     {
         $params = ['type' => 'table', 'name' => $tableName];
         $select = $this->select('sql', 'sqlite_master', $params);

--- a/src/Codeception/Lib/Driver/Sqlite.php
+++ b/src/Codeception/Lib/Driver/Sqlite.php
@@ -6,6 +6,7 @@ namespace Codeception\Lib\Driver;
 
 use Codeception\Configuration;
 use Codeception\Exception\ModuleException;
+use PDO;
 
 class Sqlite extends Db
 {
@@ -17,7 +18,6 @@ class Sqlite extends Db
      * @var string
      */
     protected $filename = '';
-    protected $con;
 
     public function __construct($dsn, $user, $password, $options = null)
     {
@@ -39,12 +39,15 @@ class Sqlite extends Db
         $this->dbh = self::connect($this->dsn, $this->user, $this->password);
     }
 
-    public function load($sql): void
+    /**
+     * @param string[] $sql
+     */
+    public function load(array $sql): void
     {
         if ($this->hasSnapshot) {
             $this->dbh = null;
             copy($this->filename . '_snapshot', $this->filename);
-            $this->dbh = new \PDO($this->dsn, $this->user, $this->password);
+            $this->dbh = new PDO($this->dsn, $this->user, $this->password);
         } else {
             if (file_exists($this->filename . '_snapshot')) {
                 unlink($this->filename . '_snapshot');
@@ -68,7 +71,7 @@ class Sqlite extends Db
             $primaryKey = [];
             $query = 'PRAGMA table_info(' . $this->getQuotedName($tableName) . ')';
             $stmt = $this->executeQuery($query, []);
-            $columns = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+            $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
             foreach ($columns as $column) {
                 if ($column['pk'] !== '0') {
@@ -87,7 +90,7 @@ class Sqlite extends Db
         $params = ['type' => 'table', 'name' => $tableName];
         $select = $this->select('sql', 'sqlite_master', $params);
         $result = $this->executeQuery($select, $params);
-        $sql = $result->fetchColumn(0);
+        $sql = $result->fetchColumn();
         return strpos($sql, ') WITHOUT ROWID') === false;
     }
 }

--- a/src/Codeception/Lib/Interfaces/Db.php
+++ b/src/Codeception/Lib/Interfaces/Db.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Lib\Interfaces;
 
 interface Db
@@ -22,12 +23,8 @@ interface Db
      * ```
      *
      * Supported operators: `<`, `>`, `>=`, `<=`, `!=`, `like`.
-     *
-     *
-     * @param string $table
-     * @param array $criteria
      */
-    public function seeInDatabase($table, $criteria = []);
+    public function seeInDatabase(string $table, array $criteria = []): void;
 
     /**
      * Effect is opposite to ->seeInDatabase
@@ -50,11 +47,8 @@ interface Db
      * ```
      *
      * Supported operators: `<`, `>`, `>=`, `<=`, `!=`, `like`.
-     *
-     * @param string $table
-     * @param array $criteria
      */
-    public function dontSeeInDatabase($table, $criteria = []);
+    public function dontSeeInDatabase(string $table, array $criteria = []): void;
 
     /**
      * Fetches a single column value from a database.
@@ -74,11 +68,7 @@ interface Db
      *
      * Supported operators: `<`, `>`, `>=`, `<=`, `!=`, `like`.
      *
-     * @param string $table
-     * @param string $column
-     * @param array $criteria
-     *
      * @return mixed
      */
-    public function grabFromDatabase($table, $column, $criteria = []);
+    public function grabFromDatabase(string $table, string $column, array $criteria = []);
 }

--- a/tests/unit/Codeception/Lib/Driver/DbTest.php
+++ b/tests/unit/Codeception/Lib/Driver/DbTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use \Codeception\Lib\Driver\Db;
 use \Codeception\Test\Unit;
 use \Codeception\Util\ReflectionHelper;
@@ -8,19 +10,19 @@ use \Codeception\Util\ReflectionHelper;
  * @group appveyor
  * @group db
  */
-class DbTest extends Unit
+final class DbTest extends Unit
 {
     /**
      * @dataProvider getWhereCriteria
      */
-    public function testGenerateWhereClause($criteria, $expectedResult)
+    public function testGenerateWhereClause(array $criteria, string $expectedResult)
     {
         $db = new Db('sqlite:tests/data/sqlite.db','root','');
         $result = ReflectionHelper::invokePrivateMethod($db, 'generateWhereClause', [&$criteria]);
         $this->assertEquals($expectedResult, $result);
     }
 
-    public function getWhereCriteria()
+    public function getWhereCriteria(): array
     {
         return [
             'like'        => [['email like' => 'mail.ua'], 'WHERE "email" LIKE ? '],

--- a/tests/unit/Codeception/Lib/Driver/MysqlTest.php
+++ b/tests/unit/Codeception/Lib/Driver/MysqlTest.php
@@ -1,5 +1,8 @@
 <?php
 
+declare(strict_types=1);
+
+use Codeception\Exception\ModuleException;
 use \Codeception\Lib\Driver\Db;
 use \Codeception\Test\Unit;
 
@@ -7,8 +10,11 @@ use \Codeception\Test\Unit;
  * @group appveyor
  * @group db
  */
-class MysqlTest extends Unit
+final class MysqlTest extends Unit
 {
+    /**
+     * @var array
+     */
     protected static $config = [
         'dsn' => 'mysql:host=localhost;dbname=codeception_test',
         'user' => 'root',
@@ -28,12 +34,12 @@ class MysqlTest extends Unit
         self::$config['password'] = getenv('MYSQL_PASSWORD') ? getenv('MYSQL_PASSWORD') : '';
 
         $sql = file_get_contents(\Codeception\Configuration::dataDir() . '/dumps/mysql.sql');
-        $sql = preg_replace('%/\*(?:(?!\*/).)*\*/%s', "", $sql);
+        $sql = preg_replace('#/\*(?:(?!\*/).)*\*/#s', "", $sql);
         self::$sql = explode("\n", $sql);
         try {
             $mysql = Db::create(self::$config['dsn'], self::$config['user'], self::$config['password']);
             $mysql->cleanup();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
         }
     }
 
@@ -41,16 +47,15 @@ class MysqlTest extends Unit
     {
         try {
             $this->mysql = Db::create(self::$config['dsn'], self::$config['user'], self::$config['password']);
-        } catch (\Exception $e) {
-            $this->markTestSkipped('Couldn\'t establish connection to database: ' . $e->getMessage());
+        } catch (Exception $e) {
+            $this->markTestSkipped("Couldn't establish connection to database: " . $e->getMessage());
         }
-        $this->mysql->cleanup();
         $this->mysql->load(self::$sql);
     }
-    
+
     public function _tearDown()
     {
-        if (isset($this->mysql)) {
+        if ($this->mysql !== null) {
             $this->mysql->cleanup();
         }
     }
@@ -115,7 +120,7 @@ class MysqlTest extends Unit
         $expectedMessage = 'You have an error in your SQL syntax; ' .
             'check the manual that corresponds to your MySQL server version for the right syntax to use near ' .
             "'VALS('')' at line 1\nSQL query being executed: \n" . $sql;
-        $this->expectException('Codeception\Exception\ModuleException');
+        $this->expectException(ModuleException::class);
         $this->expectExceptionMessage( $expectedMessage);
         $this->mysql->load([$sql]);
     }

--- a/tests/unit/Codeception/Lib/Driver/SqliteTest.php
+++ b/tests/unit/Codeception/Lib/Driver/SqliteTest.php
@@ -1,14 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
+use Codeception\Exception\ModuleException;
 use \Codeception\Lib\Driver\Db;
+use Codeception\Lib\Driver\Sqlite;
 use \Codeception\Test\Unit;
 
 /**
  * @group db
  * Class SqliteTest
  */
-class SqliteTest extends Unit
+final class SqliteTest extends Unit
 {
+    /**
+     * @var array<string, string>
+     */
     protected static $config = array(
         'dsn' => 'sqlite:tests/data/sqlite.db',
         'user' => 'root',
@@ -16,23 +23,23 @@ class SqliteTest extends Unit
     );
 
     /**
-     * @var \Codeception\Lib\Driver\Sqlite
+     * @var Sqlite
      */
     protected static $sqlite;
+
     protected static $sql;
 
     public static function _setUpBeforeClass()
     {
         $dumpFile = '/dumps/sqlite.sql';
         $sql = file_get_contents(\Codeception\Configuration::dataDir() . $dumpFile);
-        $sql = preg_replace('%/\*(?:(?!\*/).)*\*/%s', "", $sql);
+        $sql = preg_replace('#/\*(?:(?!\*/).)*\*/#s', "", $sql);
         self::$sql = explode("\n", $sql);
     }
 
     public function _setUp()
     {
         self::$sqlite = Db::create(self::$config['dsn'], self::$config['user'], self::$config['password']);
-        self::$sqlite->cleanup();
         self::$sqlite->load(self::$sql);
     }
 
@@ -76,7 +83,7 @@ class SqliteTest extends Unit
 
     public function testThrowsExceptionIfInMemoryDatabaseIsUsed()
     {
-        $this->expectException('\Codeception\Exception\ModuleException');
+        $this->expectException(ModuleException::class);
         $this->expectExceptionMessage(':memory: database is not supported');
 
         Db::create('sqlite::memory:', '', '');
@@ -87,9 +94,10 @@ class SqliteTest extends Unit
      */
     public function testLoadDumpEndingWithoutDelimiter()
     {
-        $newDriver = new \Codeception\Lib\Driver\Sqlite(self::$config['dsn'], '', '');
-        $newDriver->load(['INSERT INTO empty_table VALUES(1, "test")']);
-        $res = $newDriver->getDbh()->query("select * from empty_table where field = 'test'");
+        $sqlite = new Sqlite(self::$config['dsn'], '', '');
+        $sqlite->load(['INSERT INTO empty_table VALUES(1, "test")']);
+        
+        $res = $sqlite->getDbh()->query("select * from empty_table where field = 'test'");
         $this->assertNotEquals(false, $res);
         $this->assertNotEmpty($res->fetchAll());
     }

--- a/tests/unit/Codeception/Module/Db/MySqlDbTest.php
+++ b/tests/unit/Codeception/Module/Db/MySqlDbTest.php
@@ -1,17 +1,22 @@
 <?php
 
-require_once \Codeception\Configuration::testsDir().'unit/Codeception/Module/Db/TestsForDb.php';
+declare(strict_types=1);
+
+use Codeception\Stub;
+use Codeception\TestInterface;
+
+require_once \Codeception\Configuration::testsDir().'unit/Codeception/Module/Db/AbstractDbTest.php';
 
 /**
  * @group db
  */
-class MySqlDbTest extends TestsForDb
+final class MySqlDbTest extends AbstractDbTest
 {
     public function getPopulator()
     {
         $config = $this->getConfig();
         $password = $config['password'] ? '-p'.$config['password'] : '';
-        return "mysql -u \$user $password \$dbname < {$config['dump']}";
+        return sprintf('mysql -u $user %s $dbname < %s', $password, $config['dump']);
     }
 
     public function getConfig()
@@ -35,9 +40,9 @@ class MySqlDbTest extends TestsForDb
      */
     public function testConnectionIsResetOnEveryTestWhenReconnectIsTrue()
     {
-        $testCase1 = \Codeception\Stub::makeEmpty('\Codeception\TestInterface');
-        $testCase2 = \Codeception\Stub::makeEmpty('\Codeception\TestInterface');
-        $testCase3 = \Codeception\Stub::makeEmpty('\Codeception\TestInterface');
+        $testCase1 = Stub::makeEmpty(TestInterface::class);
+        $testCase2 = Stub::makeEmpty(TestInterface::class);
+        $testCase3 = Stub::makeEmpty(TestInterface::class);
 
 
         $this->module->_setConfig(['reconnect' => false]);
@@ -45,6 +50,7 @@ class MySqlDbTest extends TestsForDb
 
         // Simulate a test that runs
         $this->module->_before($testCase1);
+        
         $connection1 = $this->module->dbh->query('SELECT CONNECTION_ID()')->fetch(PDO::FETCH_COLUMN);
         $this->module->_after($testCase1);
 
@@ -55,6 +61,7 @@ class MySqlDbTest extends TestsForDb
         $this->module->_afterSuite();
 
         $this->module->_setConfig(['reconnect' => true]);
+        
         $this->module->_before($testCase3);
         $connection3 = $this->module->dbh->query('SELECT CONNECTION_ID()')->fetch(PDO::FETCH_COLUMN);
         $this->module->_after($testCase3);
@@ -72,7 +79,8 @@ class MySqlDbTest extends TestsForDb
             'USE ' . $dbName . ';',
         ];
         $this->module->_reconfigure($config);
-        $this->module->_before(\Codeception\Stub::makeEmpty('\Codeception\TestInterface'));
+        $this->module->_before(Stub::makeEmpty(TestInterface::class));
+        
         $usedDatabaseName = $this->module->dbh->query('SELECT DATABASE();')->fetch(PDO::FETCH_COLUMN);
 
         $this->assertEquals($dbName, $usedDatabaseName);
@@ -90,5 +98,4 @@ class MySqlDbTest extends TestsForDb
             ],
             $emails);
     }
-
 }

--- a/tests/unit/Codeception/Module/Db/Populator/DbPopulatorTest.php
+++ b/tests/unit/Codeception/Module/Db/Populator/DbPopulatorTest.php
@@ -1,16 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 use Codeception\Lib\DbPopulator;
+use Codeception\Test\Unit;
 
 /**
  * @group db
  * Class DbPopulatorTest
  */
-class DbPopulatorTest extends \Codeception\Test\Unit
+final class DbPopulatorTest extends Unit
 {
     public function testCommandBuilderInterpolatesVariables()
     {
-        $populator = new DbPopulator(
+        $dbPopulator = new DbPopulator(
             [
                 'populate'  => true,
                 'dsn'       => 'mysql:host=127.0.0.1;dbname=my_db',
@@ -23,13 +26,13 @@ class DbPopulatorTest extends \Codeception\Test\Unit
 
         $this->assertEquals(
             ['mysql -u root -h 127.0.0.1 -D my_db < tests/data/dumps/sqlite.sql'],
-            $populator->buildCommands()
+            $dbPopulator->buildCommands()
         );
     }
 
     public function testCommandBuilderInterpolatesVariablesMultiDump()
     {
-        $populator = new DbPopulator(
+        $dbPopulator = new DbPopulator(
             [
                 'populate'  => true,
                 'dsn'       => 'mysql:host=127.0.0.1;dbname=my_db',
@@ -48,21 +51,19 @@ class DbPopulatorTest extends \Codeception\Test\Unit
                 'mysql -u root -h 127.0.0.1 -D my_db < tests/data/dumps/sqlite.sql',
                 'mysql -u root -h 127.0.0.1 -D my_db < tests/data/dumps/sqlite2.sql'
             ],
-            $populator->buildCommands()
+            $dbPopulator->buildCommands()
         );
     }
 
     public function testCommandBuilderWontTouchVariablesNotFound()
     {
-        $populator = new DbPopulator([
+        $dbPopulator = new DbPopulator([
             'populator' => 'noop_tool -u $user -h $host -D $dbname < $dump',
             'user' => 'root',
         ]);
         $this->assertEquals(
             ['noop_tool -u root -h $host -D $dbname < $dump'],
-            $populator->buildCommands()
+            $dbPopulator->buildCommands()
         );
-
     }
-
 }

--- a/tests/unit/Codeception/Module/Db/PostgreSqlDbTest.php
+++ b/tests/unit/Codeception/Module/Db/PostgreSqlDbTest.php
@@ -1,11 +1,13 @@
 <?php
 
-require_once \Codeception\Configuration::testsDir().'unit/Codeception/Module/Db/TestsForDb.php';
+declare(strict_types=1);
+
+require_once \Codeception\Configuration::testsDir().'unit/Codeception/Module/Db/AbstractDbTest.php';
 
 /**
  * @group db
  */
-class PostgreSqlDbTest extends TestsForDb
+final class PostgreSqlDbTest extends AbstractDbTest
 {
     public function getPopulator()
     {
@@ -29,5 +31,4 @@ class PostgreSqlDbTest extends TestsForDb
             'populate' => true
         ];
     }
-
 }

--- a/tests/unit/Codeception/Module/Db/SqliteDbTest.php
+++ b/tests/unit/Codeception/Module/Db/SqliteDbTest.php
@@ -1,15 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
+use Codeception\Stub;
+use Codeception\TestInterface;
 use Codeception\Util\ActionSequence;
 
-require_once \Codeception\Configuration::testsDir().'unit/Codeception/Module/Db/TestsForDb.php';
+require_once \Codeception\Configuration::testsDir().'unit/Codeception/Module/Db/AbstractDbTest.php';
 
 /**
  * @group appveyor
  * @group db
  * Class SqliteDbTest
  */
-class SqliteDbTest extends TestsForDb
+final class SqliteDbTest extends AbstractDbTest
 {
     public function getPopulator()
     {
@@ -39,9 +43,9 @@ class SqliteDbTest extends TestsForDb
 
     public function testConnectionIsResetOnEveryTestWhenReconnectIsTrue()
     {
-        $testCase1 = \Codeception\Stub::makeEmpty('\Codeception\TestInterface');
-        $testCase2 = \Codeception\Stub::makeEmpty('\Codeception\TestInterface');
-        $testCase3 = \Codeception\Stub::makeEmpty('\Codeception\TestInterface');
+        $testCase1 = Stub::makeEmpty(TestInterface::class);
+        $testCase2 = Stub::makeEmpty(TestInterface::class);
+        $testCase3 = Stub::makeEmpty(TestInterface::class);
 
 
         $this->module->_setConfig(['reconnect' => false]);
@@ -49,6 +53,7 @@ class SqliteDbTest extends TestsForDb
 
         // Simulate a test that runs
         $this->module->_before($testCase1);
+        
         $connection1 = spl_object_hash($this->module->dbh);
         $this->module->_after($testCase1);
 
@@ -59,6 +64,7 @@ class SqliteDbTest extends TestsForDb
         $this->module->_afterSuite();
 
         $this->module->_setConfig(['reconnect' => true]);
+        
         $this->module->_before($testCase3);
         $connection3 = spl_object_hash($this->module->dbh);
         $this->module->_after($testCase3);
@@ -104,8 +110,8 @@ class SqliteDbTest extends TestsForDb
         );
         $this->module->_beforeSuite();
 
-        $testCase1 = \Codeception\Stub::makeEmpty('\Codeception\TestInterface');
-        $testCase2 = \Codeception\Stub::makeEmpty('\Codeception\TestInterface');
+        $testCase1 = Stub::makeEmpty(TestInterface::class);
+        $testCase2 = Stub::makeEmpty(TestInterface::class);
         $testDataInDb1 = ['name' => 'userdb1', 'email' => 'userdb1@example.org'];
         $testDataInDb2 = ['name' => 'userdb2', 'email' => 'userdb2@example.org'];
 
@@ -209,8 +215,8 @@ class SqliteDbTest extends TestsForDb
 
     public function testMultiDatabaseWithRemoveInserted()
     {
-        $testCase1 = \Codeception\Stub::makeEmpty('\Codeception\TestInterface');
-        $testCase2 = \Codeception\Stub::makeEmpty('\Codeception\TestInterface');
+        $testCase1 = Stub::makeEmpty(TestInterface::class);
+        $testCase2 = Stub::makeEmpty(TestInterface::class);
         $config = array_merge($this->getConfig(), [
             'dsn' => 'sqlite:tests/data/sqlite1.db',
             'cleanup' => false
@@ -228,17 +234,12 @@ class SqliteDbTest extends TestsForDb
 
         $this->module->haveInDatabase('users', $testDataInDb1);
         $this->module->seeInDatabase('users', $testDataInDb1);
-        $this->module->amConnectedToDatabase('db2', function ($module) use ($testDataInDb2) {
-            $module->haveInDatabase('users', $testDataInDb2);
-            $module->seeInDatabase('users', $testDataInDb2);
-        });
+        $this->module->amConnectedToDatabase('db2');
         $this->module->_after($testCase1);
 
         $this->module->_before($testCase2);
         $this->module->dontSeeInDatabase('users', $testDataInDb1);
-        $this->module->amConnectedToDatabase('db2', function ($module) use ($testDataInDb2) {
-            $module->dontSeeInDatabase('users', $testDataInDb2);
-        });
+        $this->module->amConnectedToDatabase('db2');
         $this->module->_after($testCase2);
     }
 }


### PR DESCRIPTION
- The minimum version of PHP is now 7.1
- Added strict types
- Added return types
- Added typehints
- Fix naming
- Removed unnecessary qualifiers