### PR TITLE
Add no_cleanup_failed option for not cleaning up failed tests

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -638,8 +638,10 @@ class Db extends Module implements DbInterface
 
     public function _failed(TestInterface $test, $fail)
     {
-        if ($this->config['no_cleanup_failed'] ?? false) {
-            $this->insertedRows = [];
+        foreach ($this->getDatabases() as $databaseKey => $databaseConfig) {
+            if ($databaseConfig['no_cleanup_failed'] ?? false) {
+                $this->insertedRows[$databaseKey] = [];
+            }
         }
     }
 

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -260,6 +260,7 @@ class Db extends Module implements DbInterface
         'waitlock' => 0,
         'dump' => null,
         'populator' => null,
+        'no_cleanup_failed' => false,
     ];
 
     /**
@@ -635,6 +636,13 @@ class Db extends Module implements DbInterface
         parent::_before($test);
     }
 
+    public function _failed(TestInterface $test, $fail)
+    {
+        if ($this->config['no_cleanup_failed'] ?? false) {
+            $this->insertedRows = [];
+        }
+    }
+
     public function _after(TestInterface $test): void
     {
         $this->removeInsertedForDatabases();
@@ -748,7 +756,8 @@ class Db extends Module implements DbInterface
     }
 
     /**
-     * Inserts an SQL record into a database. This record will be erased after the test.
+     * Inserts an SQL record into a database. This record will be erased after the test, 
+     * unless you've configured "no_cleanup_failed", and the test fails. 
      *
      * ```php
      * <?php

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -62,7 +62,7 @@ use PDOException;
  * * ssl_cipher - list of one or more permissible ciphers to use for SSL encryption (MySQL specific, @see http://php.net/manual/de/ref.pdo-mysql.php#pdo.constants.mysql-attr-cipher)
  * * databases - include more database configs and switch between them in tests.
  * * initial_queries - list of queries to be executed right after connection to the database has been initiated, i.e. creating the database if it does not exist or preparing the database collation
- *
+ * * skip_cleanup_if_failed - Do not perform the cleanup if the tests failed. If this is used, manual cleanup might be required when re-running
  * ## Example
  *
  *     modules:
@@ -76,6 +76,7 @@ use PDOException;
  *              cleanup: true
  *              reconnect: true
  *              waitlock: 10
+ *              skip_cleanup_if_failed: true
  *              ssl_key: '/path/to/client-key.pem'
  *              ssl_cert: '/path/to/client-cert.pem'
  *              ssl_ca: '/path/to/ca-cert.pem'
@@ -260,7 +261,7 @@ class Db extends Module implements DbInterface
         'waitlock' => 0,
         'dump' => null,
         'populator' => null,
-        'no_cleanup_failed' => false,
+        'skip_cleanup_if_failed' => false,
     ];
 
     /**
@@ -639,7 +640,7 @@ class Db extends Module implements DbInterface
     public function _failed(TestInterface $test, $fail)
     {
         foreach ($this->getDatabases() as $databaseKey => $databaseConfig) {
-            if ($databaseConfig['no_cleanup_failed'] ?? false) {
+            if ($databaseConfig['skip_cleanup_if_failed'] ?? false) {
                 $this->insertedRows[$databaseKey] = [];
             }
         }
@@ -759,7 +760,7 @@ class Db extends Module implements DbInterface
 
     /**
      * Inserts an SQL record into a database. This record will be erased after the test, 
-     * unless you've configured "no_cleanup_failed", and the test fails. 
+     * unless you've configured "skip_cleanup_if_failed", and the test fails. 
      *
      * ```php
      * <?php


### PR DESCRIPTION
I thought I'd add an option for not having it cleanup the database in case the test failed. 