### PR TITLE
Update comments on grabFromDatabase

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -936,8 +936,8 @@ class Db extends Module implements DbInterface
      *
      * ```php
      * <?php
-     * $post = $I->grabFromDatabase('posts', ['num_comments >=' => 100]);
-     * $user = $I->grabFromDatabase('users', ['email like' => 'miles%']);
+     * $postNum = $I->grabFromDatabase('posts', 'num_comments', ['num_comments >=' => 100]);
+     * $mail = $I->grabFromDatabase('users', 'email', ['email like' => 'miles%']);
      * ```
      *
      * Supported operators: `<`, `>`, `>=`, `<=`, `!=`, `like`.


### PR DESCRIPTION
I referred to the following document and corrected the comment because it seems that there was a defect.
https://codeception.com/docs/modules/Db#grabFromDatabase

```
$post = $I->grabFromDatabase('posts', ['num_comments >=' => 100]);
$user = $I->grabFromDatabase('users', ['email like' => 'miles%']);
```
Since there is no second argument, it will not work if this sample code is used as it is.