### PR TITLE
feat: allow absolute path in dump files

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -532,18 +532,24 @@ class Db extends Module implements DbInterface
      * @return bool|null|string|string[]
      * @throws ModuleConfigException
      */
-    private function readSqlFile(string $filePath): ?string
+    private function readSqlFile(string $configPath): ?string
     {
-        if (!file_exists(Configuration::projectDir() . $filePath)) {
+        if(file_exists($configPath)) {
+           $dumpFile = $configPath;
+        }elseif (file_exists(Configuration::projectDir().$configPath)){
+            $dumpFile = Configuration::projectDir().$configPath;
+        }else {
             throw new ModuleConfigException(
                 __CLASS__,
-                "\nFile with dump doesn't exist.\n"
-                . "Please, check path for sql file: "
-                . $filePath
+                sprintf(
+                    "Could not find dump file from config value.\nTried:\n%s\nand\n%s",
+                    $configPath,
+                    Configuration::projectDir().$configPath
+                )
             );
         }
-
-        $sql = file_get_contents(Configuration::projectDir() . $filePath);
+        
+        $sql = file_get_contents($dumpFile);
 
         // remove C-style comments (except MySQL directives)
         return preg_replace('#/\*(?!!\d+).*?\*/#s', '', $sql);


### PR DESCRIPTION
This is highly useful in multi-application setups
where dump files may not be inside the project
directory but in a shared fixture directory.

The current alternative is to symlink each file into the project dir.