### PR TITLE
feat: mysql helper to grab entire rows

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -729,7 +729,7 @@ class Db extends Module implements DbInterface
         $databaseKey = empty($databaseKey) ?  self::DEFAULT_DATABASE : $databaseKey;
         $databaseConfig = empty($databaseConfig) ?  $this->config : $databaseConfig;
 
-        if (array_key_exists('populator', $databaseConfig) && !empty($databaseConfig['populator'])) {
+        if (!empty($databaseConfig['populator'])) {
             $this->loadDumpUsingPopulator($databaseKey, $databaseConfig);
             return;
         }
@@ -981,7 +981,9 @@ class Db extends Module implements DbInterface
 
         $result = $sth->fetch(PDO::FETCH_ASSOC, 0);
 
-        if ($result === false) throw new \AssertionError("No matching row found");
+        if ($result === false) {
+            throw new \AssertionError("No matching row found");
+        }
 
         return $result;
     }

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -951,6 +951,7 @@ class Db extends Module implements DbInterface
 
     /**
      * Fetches a whole entry from a database.
+     * Make the test fail if the entry is not found.
      * Provide table name, desired column and criteria.
      *
      * ``` php
@@ -967,7 +968,8 @@ class Db extends Module implements DbInterface
      *
      * Supported operators: `<`, `>`, `>=`, `<=`, `!=`, `like`.
      *
-     * @return mixed Returns a single entry value or false if it fails
+     * @return array Returns a single entry value
+     * @throws PDOException|Exception
      */
     public function grabEntryFromDatabase(string $table, array $criteria = [])
     {
@@ -977,7 +979,11 @@ class Db extends Module implements DbInterface
         $this->debugSection('Parameters', $parameters);
         $sth = $this->_getDriver()->executeQuery($query, $parameters);
 
-        return $sth->fetch(PDO::FETCH_ASSOC, 0);
+        $result = $sth->fetch(PDO::FETCH_ASSOC, 0);
+
+        if ($result === false) throw new \AssertionError("No matching row found");
+
+        return $result;
     }
 
     /**
@@ -998,7 +1004,8 @@ class Db extends Module implements DbInterface
      *
      * Supported operators: `<`, `>`, `>=`, `<=`, `!=`, `like`.
      *
-     * @return mixed Returns an array of all matched rows or false if it fails
+     * @return array Returns an array of all matched rows
+     * @throws PDOException|Exception
      */
     public function grabEntriesFromDatabase(string $table, array $criteria = [])
     {

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -729,7 +729,7 @@ class Db extends Module implements DbInterface
         $databaseKey = empty($databaseKey) ?  self::DEFAULT_DATABASE : $databaseKey;
         $databaseConfig = empty($databaseConfig) ?  $this->config : $databaseConfig;
 
-        if ($databaseConfig['populator']) {
+        if (array_key_exists('populator', $databaseConfig) && !empty($databaseConfig['populator'])) {
             $this->loadDumpUsingPopulator($databaseKey, $databaseConfig);
             return;
         }
@@ -759,8 +759,8 @@ class Db extends Module implements DbInterface
     }
 
     /**
-     * Inserts an SQL record into a database. This record will be erased after the test, 
-     * unless you've configured "skip_cleanup_if_failed", and the test fails. 
+     * Inserts an SQL record into a database. This record will be erased after the test,
+     * unless you've configured "skip_cleanup_if_failed", and the test fails.
      *
      * ```php
      * <?php
@@ -947,6 +947,68 @@ class Db extends Module implements DbInterface
     public function grabFromDatabase(string $table, string $column, array $criteria = [])
     {
         return $this->proceedSeeInDatabase($table, $column, $criteria);
+    }
+
+    /**
+     * Fetches a whole entry from a database.
+     * Provide table name, desired column and criteria.
+     *
+     * ``` php
+     * <?php
+     * $mail = $I->grabEntryFromDatabase('users', array('name' => 'Davert'));
+     * ```
+     * Comparison expressions can be used as well:
+     *
+     * ```php
+     * <?php
+     * $post = $I->grabEntryFromDatabase('posts', ['num_comments >=' => 100]);
+     * $user = $I->grabEntryFromDatabase('users', ['email like' => 'miles%']);
+     * ```
+     *
+     * Supported operators: `<`, `>`, `>=`, `<=`, `!=`, `like`.
+     *
+     * @return mixed Returns a single entry value or false if it fails
+     */
+    public function grabEntryFromDatabase(string $table, array $criteria = [])
+    {
+        $query      = $this->_getDriver()->select('*', $table, $criteria);
+        $parameters = array_values($criteria);
+        $this->debugSection('Query', $query);
+        $this->debugSection('Parameters', $parameters);
+        $sth = $this->_getDriver()->executeQuery($query, $parameters);
+
+        return $sth->fetch(PDO::FETCH_ASSOC, 0);
+    }
+
+    /**
+     * Fetches a set of entries from a database.
+     * Provide table name and criteria.
+     *
+     * ``` php
+     * <?php
+     * $mail = $I->grabEntriesFromDatabase('users', array('name' => 'Davert'));
+     * ```
+     * Comparison expressions can be used as well:
+     *
+     * ```php
+     * <?php
+     * $post = $I->grabEntriesFromDatabase('posts', ['num_comments >=' => 100]);
+     * $user = $I->grabEntriesFromDatabase('users', ['email like' => 'miles%']);
+     * ```
+     *
+     * Supported operators: `<`, `>`, `>=`, `<=`, `!=`, `like`.
+     *
+     * @return mixed Returns an array of all matched rows or false if it fails
+     */
+    public function grabEntriesFromDatabase(string $table, array $criteria = [])
+    {
+        $query      = $this->_getDriver()->select('*', $table, $criteria);
+        $parameters = array_values($criteria);
+        $this->debugSection('Query', $query);
+        $this->debugSection('Parameters', $parameters);
+        $sth = $this->_getDriver()->executeQuery($query, $parameters);
+
+        return $sth->fetchAll(PDO::FETCH_ASSOC);
     }
 
     /**

--- a/tests/unit/Codeception/Module/Db/AbstractDbTest.php
+++ b/tests/unit/Codeception/Module/Db/AbstractDbTest.php
@@ -175,7 +175,7 @@ abstract class AbstractDbTest extends Unit
                 'cleanup'   => true,
             ]
         );
-        $this->module->_loadDump();
+        $this->module->_loadDump(null, $this->getConfig());
         $this->assertTrue($this->module->_isPopulated());
         $this->module->seeInDatabase('users', ['name' => 'davert']);
     }

--- a/tests/unit/Codeception/Module/Db/MySqlDbTest.php
+++ b/tests/unit/Codeception/Module/Db/MySqlDbTest.php
@@ -103,10 +103,14 @@ final class MySqlDbTest extends AbstractDbTest
             $emails);
     }
 
-    public function testGrabEntryFromDatabaseShouldReturnFalseIfNotFound()
+    public function testGrabEntryFromDatabaseShouldFailIfNotFound()
     {
-        $result = $this->module->grabEntryFromDatabase('users', ['email' => 'doesnot@exist.info']);
-        $this->assertFalse($result);
+        try {
+            $this->module->grabEntryFromDatabase('users', ['email' => 'doesnot@exist.info']);
+            $this->fail("should have thrown an exception");
+        } catch (\Throwable $t) {
+            $this->assertInstanceOf(AssertionError::class, $t);
+        }
     }
 
     public function testGrabEntryFromDatabaseShouldReturnASingleEntry()

--- a/tests/unit/Codeception/Module/Db/MySqlDbTest.php
+++ b/tests/unit/Codeception/Module/Db/MySqlDbTest.php
@@ -51,7 +51,7 @@ final class MySqlDbTest extends AbstractDbTest
 
         // Simulate a test that runs
         $this->module->_before($testCase1);
-        
+
         $connection1 = $this->module->dbh->query('SELECT CONNECTION_ID()')->fetch(PDO::FETCH_COLUMN);
         $this->module->_after($testCase1);
 
@@ -83,7 +83,7 @@ final class MySqlDbTest extends AbstractDbTest
         ];
         $this->module->_reconfigure($config);
         $this->module->_before(Stub::makeEmpty(TestInterface::class));
-        
+
         $usedDatabaseName = $this->module->dbh->query('SELECT DATABASE();')->fetch(PDO::FETCH_COLUMN);
 
         $this->assertSame($dbName, $usedDatabaseName);
@@ -91,6 +91,7 @@ final class MySqlDbTest extends AbstractDbTest
 
     public function testGrabColumnFromDatabase()
     {
+        $this->module->_beforeSuite();
         $emails = $this->module->grabColumnFromDatabase('users', 'email');
         $this->assertSame(
             [
@@ -100,5 +101,50 @@ final class MySqlDbTest extends AbstractDbTest
                 'charlie@parker.com',
             ],
             $emails);
+    }
+
+    public function testGrabEntryFromDatabaseShouldReturnFalseIfNotFound()
+    {
+        $result = $this->module->grabEntryFromDatabase('users', ['email' => 'doesnot@exist.info']);
+        $this->assertEquals(false, $result);
+    }
+
+    public function testGrabEntryFromDatabaseShouldReturnASingleEntry()
+    {
+        $this->module->_beforeSuite();
+        $result = $this->module->grabEntryFromDatabase('users', ['is_active' => true]);
+
+        $this->assertEquals(false, array_key_exists(0, $result));
+    }
+
+    public function testGrabEntryFromDatabaseShouldReturnAnAssocArray()
+    {
+        $this->module->_beforeSuite();
+        $result = $this->module->grabEntryFromDatabase('users', ['is_active' => true]);
+
+        $this->assertEquals(true, array_key_exists('is_active', $result));
+    }
+
+    public function testGrabEntriesFromDatabaseShouldReturnAnEmptyArrayIfNoRowMatches()
+    {
+        $this->module->_beforeSuite();
+        $result = $this->module->grabEntriesFromDatabase('users', ['email' => 'doesnot@exist.info']);
+        $this->assertEquals([], $result);
+    }
+
+    public function testGrabEntriesFromDatabaseShouldReturnAllMatchedRows()
+    {
+        $this->module->_beforeSuite();
+        $result = $this->module->grabEntriesFromDatabase('users', ['is_active' => true]);
+
+        $this->assertEquals(3, count($result));
+    }
+
+    public function testGrabEntriesFromDatabaseShouldReturnASetOfAssocArray()
+    {
+        $this->module->_beforeSuite();
+        $result = $this->module->grabEntriesFromDatabase('users', ['is_active' => true]);
+
+        $this->assertEquals(true, array_key_exists('is_active', $result[0]));
     }
 }

--- a/tests/unit/Codeception/Module/Db/MySqlDbTest.php
+++ b/tests/unit/Codeception/Module/Db/MySqlDbTest.php
@@ -106,7 +106,7 @@ final class MySqlDbTest extends AbstractDbTest
     public function testGrabEntryFromDatabaseShouldReturnFalseIfNotFound()
     {
         $result = $this->module->grabEntryFromDatabase('users', ['email' => 'doesnot@exist.info']);
-        $this->assertEquals(false, $result);
+        $this->assertFalse($result);
     }
 
     public function testGrabEntryFromDatabaseShouldReturnASingleEntry()
@@ -114,7 +114,7 @@ final class MySqlDbTest extends AbstractDbTest
         $this->module->_beforeSuite();
         $result = $this->module->grabEntryFromDatabase('users', ['is_active' => true]);
 
-        $this->assertEquals(false, array_key_exists(0, $result));
+        $this->assertArrayNotHasKey(0, $result);
     }
 
     public function testGrabEntryFromDatabaseShouldReturnAnAssocArray()
@@ -122,7 +122,7 @@ final class MySqlDbTest extends AbstractDbTest
         $this->module->_beforeSuite();
         $result = $this->module->grabEntryFromDatabase('users', ['is_active' => true]);
 
-        $this->assertEquals(true, array_key_exists('is_active', $result));
+        $this->assertArrayHasKey('is_active', $result);
     }
 
     public function testGrabEntriesFromDatabaseShouldReturnAnEmptyArrayIfNoRowMatches()
@@ -137,7 +137,7 @@ final class MySqlDbTest extends AbstractDbTest
         $this->module->_beforeSuite();
         $result = $this->module->grabEntriesFromDatabase('users', ['is_active' => true]);
 
-        $this->assertEquals(3, count($result));
+        $this->assertCount(3, $result);
     }
 
     public function testGrabEntriesFromDatabaseShouldReturnASetOfAssocArray()

--- a/tests/unit/Codeception/Module/Db/MySqlDbTest.php
+++ b/tests/unit/Codeception/Module/Db/MySqlDbTest.php
@@ -150,6 +150,7 @@ final class MySqlDbTest extends AbstractDbTest
         $result = $this->module->grabEntriesFromDatabase('users', ['is_active' => true]);
 
         $this->assertEquals(true, array_key_exists('is_active', $result[0]));
+    }
 
     public function testHaveInDatabaseAutoIncrementOnANonPrimaryKey()
     {


### PR DESCRIPTION
This main purpose of this PR is to close #9 by adding two methods : 

```php
grabEntryFromDatabase($table, $criteria); // Fetch the first matching row
grabEntriesFromDatabase($table, $criteria); // Fetch all matching rows
```

I've joined some tests to cover their respective behaviour.

Also, I made two small changes : 

1. Changed the test of the existence of a key that triggered a warning, making tests fails. The logic has not been changed.
2. Changed the call of `loadDump()` to pass the configuration, otherwise it would use the `mysql.sock`, which is not present when using a remote database (i.e: container).

If this PR goes through, I will port the modification to the branch `3.x`.