### PR TITLE
Feat: `haveInDatabase` tear down use row values if primary key values are available

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -801,8 +801,13 @@ class Db extends Module implements DbInterface
         $primaryKey = $this->_getDriver()->getPrimaryKey($table);
         $primary = [];
         if ($primaryKey !== []) {
-            if ($id && count($primaryKey) === 1) {
-                $primary [$primaryKey[0]] = $id;
+            $filledKeys = array_intersect($primaryKey, array_keys($row));
+            $primaryKeyIsFilled = count($filledKeys) === count($primaryKey);
+
+            if ($primaryKeyIsFilled) {
+                $primary = array_intersect_key($row, array_flip($primaryKey));
+            } elseif ($id && count($primaryKey) === 1) {
+                $primary[$primaryKey[0]] = $id;
             } else {
                 foreach ($primaryKey as $column) {
                     if (isset($row[$column])) {

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -759,8 +759,8 @@ class Db extends Module implements DbInterface
     }
 
     /**
-     * Inserts an SQL record into a database. This record will be erased after the test, 
-     * unless you've configured "skip_cleanup_if_failed", and the test fails. 
+     * Inserts an SQL record into a database. This record will be erased after the test,
+     * unless you've configured "skip_cleanup_if_failed", and the test fails.
      *
      * ```php
      * <?php
@@ -802,12 +802,14 @@ class Db extends Module implements DbInterface
         $primary = [];
         if ($primaryKey !== []) {
             $filledKeys = array_intersect($primaryKey, array_keys($row));
-            $primaryKeyIsFilled = count($filledKeys) === count($primaryKey);
+            $missingPrimaryKeyColumns = array_diff_key($primaryKey, $filledKeys);
 
-            if ($primaryKeyIsFilled) {
+            if (count($missingPrimaryKeyColumns) === 0) {
                 $primary = array_intersect_key($row, array_flip($primaryKey));
-            } elseif ($id && count($primaryKey) === 1) {
-                $primary[$primaryKey[0]] = $id;
+            } elseif (count($missingPrimaryKeyColumns) === 1) {
+                $primary = array_intersect_key($row, array_flip($primaryKey));
+                $missingColumn = reset($missingPrimaryKeyColumns);
+                $primary[$missingColumn] = $id;
             } else {
                 foreach ($primaryKey as $column) {
                     if (isset($row[$column])) {

--- a/tests/data/dumps/mysql.sql
+++ b/tests/data/dumps/mysql.sql
@@ -94,6 +94,16 @@ CREATE TABLE `no_pk` (
   `status` varchar(255) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+CREATE TABLE `auto_increment_not_on_pk` (
+    `id` int(11) NOT NULL,
+    `counter` int(11) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE INDEX counter ON `auto_increment_not_on_pk` (counter);
+ALTER TABLE `auto_increment_not_on_pk`
+    MODIFY counter int AUTO_INCREMENT;
+
 CREATE TABLE `empty_table` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `field` varchar(255),

--- a/tests/data/dumps/mysql.sql
+++ b/tests/data/dumps/mysql.sql
@@ -104,6 +104,13 @@ CREATE INDEX counter ON `auto_increment_not_on_pk` (counter);
 ALTER TABLE `auto_increment_not_on_pk`
     MODIFY counter int AUTO_INCREMENT;
 
+
+CREATE TABLE `auto_increment_on_composite_pk` (
+    `id` int(11) NOT NULL,
+    `counter` int(11) AUTO_INCREMENT NOT NULL,
+PRIMARY KEY (`id`, `counter`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
 CREATE TABLE `empty_table` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `field` varchar(255),

--- a/tests/unit/Codeception/Module/Db/MySqlDbTest.php
+++ b/tests/unit/Codeception/Module/Db/MySqlDbTest.php
@@ -51,7 +51,7 @@ final class MySqlDbTest extends AbstractDbTest
 
         // Simulate a test that runs
         $this->module->_before($testCase1);
-        
+
         $connection1 = $this->module->dbh->query('SELECT CONNECTION_ID()')->fetch(PDO::FETCH_COLUMN);
         $this->module->_after($testCase1);
 
@@ -83,7 +83,7 @@ final class MySqlDbTest extends AbstractDbTest
         ];
         $this->module->_reconfigure($config);
         $this->module->_before(Stub::makeEmpty(TestInterface::class));
-        
+
         $usedDatabaseName = $this->module->dbh->query('SELECT DATABASE();')->fetch(PDO::FETCH_COLUMN);
 
         $this->assertSame($dbName, $usedDatabaseName);
@@ -112,5 +112,17 @@ final class MySqlDbTest extends AbstractDbTest
         $this->module->_after(Stub::makeEmpty(TestInterface::class));
 
         $this->module->dontSeeInDatabase('auto_increment_not_on_pk', $testData);
+    }
+
+    public function testHaveInDatabaseAutoIncrementOnCompositePrimaryKey()
+    {
+        $testData = [
+            'id' => 777,
+        ];
+        $this->module->haveInDatabase('auto_increment_on_composite_pk', $testData);
+        $this->module->seeInDatabase('auto_increment_on_composite_pk', $testData);
+        $this->module->_after(Stub::makeEmpty(TestInterface::class));
+
+        $this->module->dontSeeInDatabase('auto_increment_on_composite_pk', $testData);
     }
 }

--- a/tests/unit/Codeception/Module/Db/MySqlDbTest.php
+++ b/tests/unit/Codeception/Module/Db/MySqlDbTest.php
@@ -101,4 +101,16 @@ final class MySqlDbTest extends AbstractDbTest
             ],
             $emails);
     }
+
+    public function testHaveInDatabaseAutoIncrementOnANonPrimaryKey()
+    {
+        $testData = [
+            'id' => 777,
+        ];
+        $this->module->haveInDatabase('auto_increment_not_on_pk', $testData);
+        $this->module->seeInDatabase('auto_increment_not_on_pk', $testData);
+        $this->module->_after(Stub::makeEmpty(TestInterface::class));
+
+        $this->module->dontSeeInDatabase('auto_increment_not_on_pk', $testData);
+    }
 }


### PR DESCRIPTION
Right now `Db::addInsertedRow()` uses the `lastInsertId` to remove the row during tear down.
In some case the primary key is not auto incremented but another column is.

```php
// auto_increment_not_on_pk : [id: int, counter: int auto_increment]
$I->haveInDatabase('auto_increment_not_on_pk', ['id' => 777]);
// created row : [id: 777, counter: 1]
```

The row being referenced with `['id' => 1]` because `$driver->lastInsertId()` returns `1`, and the module assumes it's the PK value.

This PR fixes this behaviour by checking if the provided values cover the primary key. If so, it uses those value, if not it follows the default behaviour.