### PR TITLE
[bugfix] #58 allow inserts with primary key nulled to be rolled back

### DIFF
--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -808,7 +808,9 @@ class Db extends Module implements DbInterface
     {
         $primaryKey = $this->_getDriver()->getPrimaryKey($table);
         $primary = [];
-        if ($primaryKey !== []) {
+        if (count($primaryKey) == 1 && is_null($row[$primaryKey[0]])) {
+            $primary[$primaryKey[0]] = $id; 
+        } elseif ($primaryKey !== []) {
             $filledKeys = array_intersect($primaryKey, array_keys($row));
             $missingPrimaryKeyColumns = array_diff_key($primaryKey, $filledKeys);
 


### PR DESCRIPTION
fixes #58 

when the row to be inserted contains `null` for its primary key column, it's most likely, that it's an auto-increment or otherwise generated primary key, so the $row value is not reliable.

in that particular case, prefer the last insert id over the row value

remark: I wanted to add tests, but I couldn't get the docker container to run for a while, and when I did, I couldn't get the tests to run successfully, so I gave up. Theoretically, the groups table has an auto increment primary key, with which this could be tested, but i didn't make it that far to actually be able to write a test.

this bug was introduced in #44 to fix another bug