### PR TITLE
feat: allow developer to define own connection

### DIFF
--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -91,8 +91,8 @@ class Db
 
     public function __destruct()
     {
-        if ($this->dbh !== null && $this->dbh->inTransaction()) {
-            $this->dbh->rollBack();
+        if ($this->getDbh() !== null && $this->getDbh()->inTransaction()) {
+            $this->getDbh()->rollBack();
         }
 
         $this->dbh = null;
@@ -271,7 +271,7 @@ class Db
     protected function sqlQuery(string $query): void
     {
         try {
-            $this->dbh->exec($query);
+            $this->getDbh()->exec($query);
         } catch (PDOException $exception) {
             throw new ModuleException(
                 \Codeception\Module\Db::class,
@@ -282,7 +282,7 @@ class Db
 
     public function executeQuery($query, array $params): PDOStatement
     {
-        $pdoStatement = $this->dbh->prepare($query);
+        $pdoStatement = $this->getDbh()->prepare($query);
         if (!$pdoStatement) {
             throw new Exception("Query '{$query}' can't be prepared.");
         }


### PR DESCRIPTION
Allow user to create connection outside of module-db, or even use connection from different module;

You could define class `MyDb` with method `getConnection` which will return instance of `\Codeception\Lib\Driver\Db` class

```
class MyDB
{
    protected static $connection;

    public static function setConnection($connection)
    {
        self::$connection = $connection;
    }

    public static function getConnection($databaseKey, $databaseConfig, $dbModule)
    {
        return new class (self::$connection) extends \Codeception\Lib\Driver\Db {
            public function __construct(protected $connection)
            {
            }

            public function getDbh(): \PDO
            {
                return $this->connection->getNativeConnection();
            }
        };
    }
}
```