### PR TITLE
Fix Db::executeQuery() for null parameter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
+        "ext-mbstring": "*",
         "ext-pdo": "*",
         "codeception/codeception": "*@dev"
     },

--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -296,7 +296,7 @@ class Db
                 $type = PDO::PARAM_BOOL;
             } elseif (is_int($param)) {
                 $type = PDO::PARAM_INT;
-            } elseif ($this->isBinary($param)) {
+            } elseif (is_string($param) && $this->isBinary($param)) {
                 $type = PDO::PARAM_LOB;
             } else {
                 $type = PDO::PARAM_STR;

--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -290,7 +290,9 @@ class Db
         $i = 0;
         foreach ($params as $param) {
             ++$i;
-            if (is_bool($param)) {
+            if (is_null($param)) {
+                $type = PDO::PARAM_NULL;
+            } elseif (is_bool($param)) {
                 $type = PDO::PARAM_BOOL;
             } elseif (is_int($param)) {
                 $type = PDO::PARAM_INT;

--- a/tests/unit/Codeception/Module/Db/AbstractDbTest.php
+++ b/tests/unit/Codeception/Module/Db/AbstractDbTest.php
@@ -69,6 +69,11 @@ abstract class AbstractDbTest extends Unit
         $this->module->seeInDatabase('users', ['uuid' => hex2bin('11edc34b01d972fa9c1d0242ac120006')]);
     }
 
+    public function testSeeInDatabaseWithNull()
+    {
+        $this->module->seeInDatabase('users', ['uuid' => null]);
+    }
+
     public function testSeeInDatabase()
     {
         $this->module->seeInDatabase('users', ['name' => 'davert']);


### PR DESCRIPTION
Seems like https://github.com/Codeception/module-db/pull/48 broke the following code

```php
$I->seeInDatabase('some_table', ['some_column => null]);
```
After updating `codeception/module-db` from `3.1.0` to `3.1.1` I get the following error:

```
[TypeError] Codeception\Lib\Driver\Db::isBinary(): Argument #1 ($string) must be of type string, null given, called in /var/www/html/vendor/codeception/module-db/src/Codeception/Lib/Driver/Db.php on line 297
```

This PR should fix that by using `PDO::PARAM_NULL` if `null` was provided in the criteria.

Fixes https://github.com/Codeception/module-db/issues/64