### PR TITLE
Support ODBC 18 in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+.PHONY: $(filter-out help, $(MAKECMDGOALS))
+.DEFAULT_GOAL := help
+
+DOCKER_COMPOSE := $(if $(shell command -v docker-compose 2> /dev/null),docker-compose,docker compose) -f docker-compose.yml
+ARCH           := $(shell uname -m)
+CURRENT_USER   := $(shell id -u):$(shell id -g)
+
+# Check if docker-compose.override.yml exists and if so, add it to DOCKER_COMPOSE
+ifneq (,$(wildcard ./docker-compose.override.yml))
+    DOCKER_COMPOSE += -f docker-compose.override.yml
+endif
+
+# Support Apple Silicon
+ifeq ($(ARCH),arm64)
+    DOCKER_COMPOSE += -f docker-compose.amd64.yml
+endif
+
+DOCKER_EXEC_PHP_WITH_USER = $(DOCKER_COMPOSE) exec -u $(CURRENT_USER) php bash -c
+
+help: ## Show this help message
+	@echo "\033[33mUsage:\033[0m\n  make [target] [arg=\"val\"...]\n\n\033[33mTargets:\033[0m"
+	@grep -hE '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[32m%-25s\033[0m %s\n", $$1, $$2}'
+
+start: ## Start the containers for testing
+	$(MAKE) -i stop
+	CURRENT_USER=$(CURRENT_USER) $(DOCKER_COMPOSE) up -d --build --force-recreate --remove-orphans
+	$(DOCKER_COMPOSE) run --rm wait -c mysql:3306,postgres:5432,mssql:1433 -t 60
+	$(MAKE) vendor
+
+stop: ## Stop and remove containers
+	$(DOCKER_COMPOSE) down --remove-orphans --volumes
+
+php-cli: ## Open bash in PHP container
+	$(DOCKER_COMPOSE) exec -u $(CURRENT_USER) php bash
+
+vendor: ## Install dependencies
+	$(DOCKER_EXEC_PHP_WITH_USER) "composer install --no-interaction --prefer-dist"
+
+test: ## Run the tests
+	$(DOCKER_EXEC_PHP_WITH_USER) "php vendor/bin/codecept run"

--- a/docker-compose.amd64.yml
+++ b/docker-compose.amd64.yml
@@ -1,0 +1,17 @@
+version: '3.9'
+
+services:
+  php:
+    platform: linux/amd64
+
+  mysql:
+    platform: linux/amd64
+
+  postgres:
+    platform: linux/amd64
+
+  mssql:
+    platform: linux/amd64
+
+  wait:
+    platform: linux/amd64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,13 @@
 version: "3.9"
 
 services:
-  php81:
-    image: codeception-module-db-php81:2.2.0
+  php:
+    container_name: codeception-module-db
     build:
       context: .
       dockerfile: ./php81.Dockerfile
     environment:
+      COMPOSER_HOME: /tmp/.composer
       MYSQL_HOST: host.docker.internal
       MYSQL_DB: codeception
       MYSQL_PASSWORD: codeception
@@ -20,7 +21,8 @@ services:
       XDEBUG_CONFIG: "client_host=host.docker.internal; client_port=9000; mode=debug; start_wih_request=1"
       PHP_IDE_CONFIG: "serverName=codeception-module-db" # the name must be the same as in your PHP -> Server -> "name" field
     volumes:
-      - ".:/var/www/html"
+      - ${HOME}/.composer:/tmp/.composer
+      - .:/var/www/html
 
   mysql:
     image: mysql:5.7
@@ -50,3 +52,5 @@ services:
       - ./tests/data/scripts:/scripts:ro
     entrypoint: [ "/bin/bash", "-c", "/scripts/mssql.sh" ]
 
+  wait:
+    image: dokku/wait

--- a/php81.Dockerfile
+++ b/php81.Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-cli
+FROM php:8.1-fpm
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
@@ -10,7 +10,7 @@ RUN apt-get update && \
         zlib1g-dev \
         libzip-dev \
         libpq-dev \
-        mariadb-client-10.5
+        default-mysql-client
 
 RUN install-php-extensions \
     pdo_mysql-stable \

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,54 @@
+# Local Test Environment
+
+## Prerequisites
+
+- Docker
+- Docker Compose
+- Make
+
+## Setup
+
+1. Clone the repository to your local machine.
+2. Navigate to the project directory.
+
+## Running the Docker Environment
+
+To start the Docker environment, use the following command:
+
+```bash
+make start
+```
+
+This command will start all the necessary containers for the application. It will also build the Docker images if they are not already built.
+
+## Running Tests
+
+To run the tests, use the following command:
+
+```bash
+make test
+```
+
+This command will execute the tests inside the PHP container.
+
+## Other Commands
+
+- To stop and remove the Docker containers, use the following command:
+
+```bash
+make stop
+```
+
+- To open a bash shell inside the PHP container, use the following command:
+
+```bash
+make php-cli
+```
+
+- To install the dependencies, use the following command:
+
+```bash
+make vendor
+```
+
+Please note that all these commands should be run from the root directory of the project where the `Makefile` is located.

--- a/tests/unit/Codeception/Module/Db/MssqlSqlSrvDbTest.php
+++ b/tests/unit/Codeception/Module/Db/MssqlSqlSrvDbTest.php
@@ -24,7 +24,7 @@ final class MssqlSqlSrvDbTest extends AbstractDbTest
         $user = getenv('MSSQL_USER') ?: 'sa';
         $password = getenv('MSSQL_PASSWORD') ?: '';
         $database = getenv('MSSQL_DB') ?: 'codeception_test';
-        $dsn = getenv('MSSQL_DSN') ?: 'sqlsrv:Server=' . $host . ';Database=' . $database;
+        $dsn = getenv('MSSQL_DSN') ?: 'sqlsrv:Server=' . $host . ';Database=' . $database . ';Encrypt=no;TrustServerCertificate=yes';
 
         return [
             'dsn' => $dsn,


### PR DESCRIPTION
This pull request aims to address compatibility issues with ODBC 18.0. The official changelog can be found here: [ODBC Driver 18.0 for SQL Server Released](https://techcommunity.microsoft.com/t5/sql-server-blog/odbc-driver-18-0-for-sql-server-released/ba-p/3169228).

Additionally, I've included documentation to enable local testing with a Docker environment with Apple Silicon support.