### PR TITLE
Configure nullable types explicitly

### DIFF
--- a/src/Codeception/Lib/DbPopulator.php
+++ b/src/Codeception/Lib/DbPopulator.php
@@ -53,7 +53,7 @@ class DbPopulator
      * @param string|null $dumpFile The dump file to build the command with.
      * @return string The resulting command string after evaluating any configuration's key
      */
-    protected function buildCommand(string $command, string $dumpFile = null): string
+    protected function buildCommand(string $command, ?string $dumpFile = null): string
     {
         $dsn = $this->config['dsn'] ?? '';
         $dsnVars = [];

--- a/src/Codeception/Lib/Driver/Db.php
+++ b/src/Codeception/Lib/Driver/Db.php
@@ -31,7 +31,7 @@ class Db
      */
     protected array $primaryKeys = [];
 
-    public static function connect(string $dsn, string $user = null, string $password = null, array $options = null): PDO
+    public static function connect(string $dsn, ?string $user = null, ?string $password = null, ?array $options = null): PDO
     {
         $dbh = new PDO($dsn, $user, $password, $options);
         $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
@@ -47,7 +47,7 @@ class Db
      *
      * @return Db|SqlSrv|MySql|Oci|PostgreSql|Sqlite
      */
-    public static function create(string $dsn, string $user = null, string $password = null, array $options = null): Db
+    public static function create(string $dsn, ?string $user = null, ?string $password = null, ?array $options = null): Db
     {
         $provider = self::getProvider($dsn);
 
@@ -78,7 +78,7 @@ class Db
      * @see https://www.php.net/manual/en/pdo.construct.php
      * @see https://www.php.net/manual/de/ref.pdo-mysql.php#pdo-mysql.constants
      */
-    public function __construct(string $dsn, string $user = null, string $password = null, array $options = null)
+    public function __construct(string $dsn, ?string $user = null, ?string $password = null, ?array $options = null)
     {
         $this->dbh = new PDO($dsn, $user, $password, $options);
         $this->dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/src/Codeception/Lib/Driver/Sqlite.php
+++ b/src/Codeception/Lib/Driver/Sqlite.php
@@ -14,7 +14,7 @@ class Sqlite extends Db
 
     protected string $filename = '';
 
-    public function __construct(string $dsn, string $user = null, string $password = null, array $options = null)
+    public function __construct(string $dsn, ?string $user = null, ?string $password = null, ?array $options = null)
     {
         $filename = substr($dsn, 7);
         if ($filename === ':memory:') {

--- a/src/Codeception/Module/Db.php
+++ b/src/Codeception/Module/Db.php
@@ -684,7 +684,7 @@ class Db extends Module implements DbInterface
         $this->insertedRows[$databaseKey] = [];
     }
 
-    public function _cleanup(string $databaseKey = null, array $databaseConfig = null): void
+    public function _cleanup(?string $databaseKey = null, ?array $databaseConfig = null): void
     {
         $databaseKey = empty($databaseKey) ?  self::DEFAULT_DATABASE : $databaseKey;
         $databaseConfig = empty($databaseConfig) ?  $this->config : $databaseConfig;
@@ -737,7 +737,7 @@ class Db extends Module implements DbInterface
         return $this->databasesPopulated[$this->currentDatabase];
     }
 
-    public function _loadDump(string $databaseKey = null, array $databaseConfig = null): void
+    public function _loadDump(?string $databaseKey = null, ?array $databaseConfig = null): void
     {
         $databaseKey = empty($databaseKey) ?  self::DEFAULT_DATABASE : $databaseKey;
         $databaseConfig = empty($databaseConfig) ?  $this->config : $databaseConfig;


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types deprecates implicitly nullable parameter types in PHP 8.4