### PR TITLE
Avoid deprecated direct access to driver and dbh property

### DIFF
--- a/tests/unit/Codeception/Module/Db/AbstractDbTest.php
+++ b/tests/unit/Codeception/Module/Db/AbstractDbTest.php
@@ -46,8 +46,8 @@ abstract class AbstractDbTest extends Unit
         $this->module->_before($testCase1);
         // Save these object instances IDs
         $driverAndConn1 = [
-            $this->module->driver,
-            $this->module->dbh
+            $this->module->_getDriver(),
+            $this->module->_getDbh()
         ];
         $this->module->_after($testCase1);
 
@@ -55,8 +55,8 @@ abstract class AbstractDbTest extends Unit
         $this->module->_before($testCase2);
 
         $driverAndConn2 = [
-            $this->module->driver,
-            $this->module->dbh
+            $this->module->_getDriver(),
+            $this->module->_getDbh()
         ];
         $this->module->_after($testCase2);
         $this->assertSame($driverAndConn2, $driverAndConn1);
@@ -157,8 +157,8 @@ abstract class AbstractDbTest extends Unit
     {
         $insertQuery = 'INSERT INTO composite_pk (group_id, id, status) VALUES (?, ?, ?)';
         //this test checks that module does not delete columns by partial primary key
-        $this->module->driver->executeQuery($insertQuery, [1, 2, 'test']);
-        $this->module->driver->executeQuery($insertQuery, [2, 1, 'test2']);
+        $this->module->_getDriver()->executeQuery($insertQuery, [1, 2, 'test']);
+        $this->module->_getDriver()->executeQuery($insertQuery, [2, 1, 'test2']);
 
         $testData = ['id' => 2, 'group_id' => 2, 'status' => 'test3'];
         $this->module->haveInDatabase('composite_pk', $testData);

--- a/tests/unit/Codeception/Module/Db/MySqlDbTest.php
+++ b/tests/unit/Codeception/Module/Db/MySqlDbTest.php
@@ -49,13 +49,13 @@ final class MySqlDbTest extends AbstractDbTest
         // Simulate a test that runs
         $this->module->_before($testCase1);
 
-        $connection1 = $this->module->dbh->query('SELECT CONNECTION_ID()')->fetch(PDO::FETCH_COLUMN);
+        $connection1 = $this->module->_getDbh()->query('SELECT CONNECTION_ID()')->fetch(PDO::FETCH_COLUMN);
         $this->module->_after($testCase1);
 
         // Simulate a second test that runs
         $this->module->_before($testCase2);
 
-        $connection2 = $this->module->dbh->query('SELECT CONNECTION_ID()')->fetch(PDO::FETCH_COLUMN);
+        $connection2 = $this->module->_getDbh()->query('SELECT CONNECTION_ID()')->fetch(PDO::FETCH_COLUMN);
         $this->module->_after($testCase2);
         $this->module->_afterSuite();
 
@@ -63,7 +63,7 @@ final class MySqlDbTest extends AbstractDbTest
 
         $this->module->_before($testCase3);
 
-        $connection3 = $this->module->dbh->query('SELECT CONNECTION_ID()')->fetch(PDO::FETCH_COLUMN);
+        $connection3 = $this->module->_getDbh()->query('SELECT CONNECTION_ID()')->fetch(PDO::FETCH_COLUMN);
         $this->module->_after($testCase3);
 
         $this->assertSame($connection1, $connection2);
@@ -81,7 +81,7 @@ final class MySqlDbTest extends AbstractDbTest
         $this->module->_reconfigure($config);
         $this->module->_before(Stub::makeEmpty(TestInterface::class));
 
-        $usedDatabaseName = $this->module->dbh->query('SELECT DATABASE();')->fetch(PDO::FETCH_COLUMN);
+        $usedDatabaseName = $this->module->_getDbh()->query('SELECT DATABASE();')->fetch(PDO::FETCH_COLUMN);
 
         $this->assertSame($dbName, $usedDatabaseName);
     }

--- a/tests/unit/Codeception/Module/Db/SqliteDbTest.php
+++ b/tests/unit/Codeception/Module/Db/SqliteDbTest.php
@@ -40,13 +40,13 @@ final class SqliteDbTest extends AbstractDbTest
         // Simulate a test that runs
         $this->module->_before($testCase1);
 
-        $connection1 = spl_object_hash($this->module->dbh);
+        $connection1 = spl_object_hash($this->module->_getDbh());
         $this->module->_after($testCase1);
 
         // Simulate a second test that runs
         $this->module->_before($testCase2);
 
-        $connection2 = spl_object_hash($this->module->dbh);
+        $connection2 = spl_object_hash($this->module->_getDbh());
         $this->module->_after($testCase2);
         $this->module->_afterSuite();
 
@@ -54,7 +54,7 @@ final class SqliteDbTest extends AbstractDbTest
 
         $this->module->_before($testCase3);
 
-        $connection3 = spl_object_hash($this->module->dbh);
+        $connection3 = spl_object_hash($this->module->_getDbh());
         $this->module->_after($testCase3);
 
         $this->assertSame($connection1, $connection2);


### PR DESCRIPTION
This PR fixes the following deprecation warnings when running the unit tests:

> Properties dbh and driver are deprecated in favor of Db::_getDbh and Db::_getDriver

Direct access was deprecated in 440e83dff2e45bb82df6afe7e3a01f6c65a51284 a few years ago.