### PR TITLE
fix: allow uppercase table names using haveInDatabase with postgreSql

### DIFF
--- a/src/Codeception/Lib/Driver/PostgreSql.php
+++ b/src/Codeception/Lib/Driver/PostgreSql.php
@@ -164,7 +164,7 @@ class PostgreSql extends Db
                 FROM   pg_index i
                 JOIN   pg_attribute a ON a.attrelid = i.indrelid
                                      AND a.attnum = ANY(i.indkey)
-                WHERE  i.indrelid = " . $this->postgreQuotedName($tableName) . "::regclass
+                WHERE  i.indrelid = '\"{$tableName}\"'::regclass
                 AND    i.indisprimary";
             $stmt = $this->executeQuery($query, []);
             $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -176,14 +176,5 @@ class PostgreSql extends Db
         }
 
         return $this->primaryKeys[$tableName];
-    }
-
-    private function postgreQuotedName(string $tableName): string
-    {
-        if (preg_match("/[A-Z\-]/", $tableName)) {
-            $tableName = sprintf('"%s"', $tableName);
-        }
-
-        return "'" . $tableName . "'";
     }
 }

--- a/src/Codeception/Lib/Driver/PostgreSql.php
+++ b/src/Codeception/Lib/Driver/PostgreSql.php
@@ -164,7 +164,7 @@ class PostgreSql extends Db
                 FROM   pg_index i
                 JOIN   pg_attribute a ON a.attrelid = i.indrelid
                                      AND a.attnum = ANY(i.indkey)
-                WHERE  i.indrelid = '{$tableName}'::regclass
+                WHERE  i.indrelid = " . $this->postgreQuotedName($tableName) . "::regclass
                 AND    i.indisprimary";
             $stmt = $this->executeQuery($query, []);
             $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -176,5 +176,14 @@ class PostgreSql extends Db
         }
 
         return $this->primaryKeys[$tableName];
+    }
+
+    private function postgreQuotedName(string $tableName): string
+    {
+        if (preg_match("/[A-Z\-]/", $tableName)) {
+            $tableName = sprintf('"%s"', $tableName);
+        }
+
+        return "'" . $tableName . "'";
     }
 }

--- a/tests/data/dumps/postgres.sql
+++ b/tests/data/dumps/postgres.sql
@@ -448,6 +448,10 @@ CREATE TABLE "no_pk" (
     "status" VARCHAR NOT NULL
 );
 
+CREATE TABLE "NoPk" (
+    "Status" VARCHAR NOT NULL
+);
+
 CREATE TABLE "order" (
     "id" INTEGER NOT NULL PRIMARY KEY,
     "name" VARCHAR NOT NULL,

--- a/tests/unit/Codeception/Module/Db/PostgreSqlDbTest.php
+++ b/tests/unit/Codeception/Module/Db/PostgreSqlDbTest.php
@@ -33,4 +33,10 @@ final class PostgreSqlDbTest extends AbstractDbTest
             'populate' => true
         ];
     }
+
+    public function testHaveInDatabaseWithIllegalTableName()
+    {
+        $testData = ['Status' => 'test'];
+        $this->module->haveInDatabase('NoPk', $testData);
+    }
 }

--- a/tests/unit/Codeception/Module/Db/PostgreSqlDbTest.php
+++ b/tests/unit/Codeception/Module/Db/PostgreSqlDbTest.php
@@ -34,7 +34,7 @@ final class PostgreSqlDbTest extends AbstractDbTest
         ];
     }
 
-    public function testHaveInDatabaseWithIllegalTableName()
+    public function testHaveInDatabaseWithUppercaseTableName()
     {
         $testData = ['Status' => 'test'];
         $this->module->haveInDatabase('NoPk', $testData);


### PR DESCRIPTION
Fix error when using `haveInDatabase()` on databases with illegal table names (like uppercase chars).

According to [PostgreSQL Wiki](https://wiki.postgresql.org/wiki/Retrieve_primary_key_columns):
>The table name must be double-quoted for otherwise illegal names (upper-case letters, reserved words etc.): '"oDD table name"'::regclass

Exception throwed:
```
  [PDOException] SQLSTATE[42P01]: Undefined table: 7 ERROR:  relation "nopk" does not exist
LINE 5:                 WHERE  i.indrelid = 'NoPk'::regclass
```

fixes #14
